### PR TITLE
Update darksusy patch to deal with slow nulike runtime

### DIFF
--- a/Backends/patches/darksusy/5.1.3/patch_darksusy_5.1.3.dif
+++ b/Backends/patches/darksusy/5.1.3/patch_darksusy_5.1.3.dif
@@ -1,6 +1,6 @@
 diff -rupN darksusy-5.1.3/configure ../installed/darksusy/5.1.3/configure
 --- darksusy-5.1.3/configure	2015-04-07 10:23:05.000000000 +0100
-+++ ../installed/darksusy/5.1.3/configure	2018-04-15 17:02:44.751922374 +0100
++++ ../installed/darksusy/5.1.3/configure	2018-05-23 15:18:58.102557401 +0100
 @@ -3337,11 +3337,11 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
  if test "${FCSET}" = "false" ; then
    if test "${FC}" = "ifort"; then
@@ -17,7 +17,7 @@ diff -rupN darksusy-5.1.3/configure ../installed/darksusy/5.1.3/configure
  
 diff -rupN darksusy-5.1.3/configure.ac ../installed/darksusy/5.1.3/configure.ac
 --- darksusy-5.1.3/configure.ac	2015-04-07 10:23:05.000000000 +0100
-+++ ../installed/darksusy/5.1.3/configure.ac	2018-04-15 17:02:44.751922374 +0100
++++ ../installed/darksusy/5.1.3/configure.ac	2018-05-23 15:18:58.102557401 +0100
 @@ -28,11 +28,11 @@ AC_PROG_FC([ifort gfortran])
  if test "${FCSET}" = "false" ; then
    if test "${FC}" = "ifort"; then 
@@ -34,7 +34,7 @@ diff -rupN darksusy-5.1.3/configure.ac ../installed/darksusy/5.1.3/configure.ac
  
 diff -rupN darksusy-5.1.3/contrib/FeynHiggs-2.9.4/makefile.in ../installed/darksusy/5.1.3/contrib/FeynHiggs-2.9.4/makefile.in
 --- darksusy-5.1.3/contrib/FeynHiggs-2.9.4/makefile.in	2013-02-10 06:43:34.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/FeynHiggs-2.9.4/makefile.in	2018-04-15 17:02:44.751922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/FeynHiggs-2.9.4/makefile.in	2018-05-23 15:18:58.102557401 +0100
 @@ -31,6 +31,9 @@ ARGS = $(PARALLEL) \
  default all lib frontend mma: force
  	cd $(BLD) && $(MAKE) $(ARGS) $@
@@ -47,7 +47,7 @@ diff -rupN darksusy-5.1.3/contrib/FeynHiggs-2.9.4/makefile.in ../installed/darks
  	-mkdir "$(LIBDIR)" "$(INCLUDEDIR)" "$(BINDIR)"
 diff -rupN darksusy-5.1.3/contrib/FeynHiggs-2.9.4/src/Decays/VecSet.F ../installed/darksusy/5.1.3/contrib/FeynHiggs-2.9.4/src/Decays/VecSet.F
 --- darksusy-5.1.3/contrib/FeynHiggs-2.9.4/src/Decays/VecSet.F	2013-02-10 06:43:34.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/FeynHiggs-2.9.4/src/Decays/VecSet.F	2018-04-15 17:02:44.751922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/FeynHiggs-2.9.4/src/Decays/VecSet.F	2018-05-23 15:18:58.102557401 +0100
 @@ -27,7 +27,7 @@
  #define EpsL(x,y)  vec_(x,y, 3, i)
  #define EpsTL(x,y) vec_(x,y, 4, i)
@@ -59,7 +59,7 @@ diff -rupN darksusy-5.1.3/contrib/FeynHiggs-2.9.4/src/Decays/VecSet.F ../install
  #define Spi(hel,om,x) spi_(x, om, hel+6, i)
 diff -rupN darksusy-5.1.3/contrib/galprop/v50p/Configure.cc ../installed/darksusy/5.1.3/contrib/galprop/v50p/Configure.cc
 --- darksusy-5.1.3/contrib/galprop/v50p/Configure.cc	1970-01-01 01:00:00.000000000 +0100
-+++ ../installed/darksusy/5.1.3/contrib/galprop/v50p/Configure.cc	2018-04-15 17:02:50.055922446 +0100
++++ ../installed/darksusy/5.1.3/contrib/galprop/v50p/Configure.cc	2018-05-23 15:19:02.282557326 +0100
 @@ -0,0 +1,24 @@
 +
 +//**.****|****.****|****.****|****.****|****.****|****.****|****.****|****.****|
@@ -87,7 +87,7 @@ diff -rupN darksusy-5.1.3/contrib/galprop/v50p/Configure.cc ../installed/darksus
 +}
 diff -rupN darksusy-5.1.3/contrib/galprop/v50p/nuc_package.cc ../installed/darksusy/5.1.3/contrib/galprop/v50p/nuc_package.cc
 --- darksusy-5.1.3/contrib/galprop/v50p/nuc_package.cc	1970-01-01 01:00:00.000000000 +0100
-+++ ../installed/darksusy/5.1.3/contrib/galprop/v50p/nuc_package.cc	2018-04-15 17:02:50.087922447 +0100
++++ ../installed/darksusy/5.1.3/contrib/galprop/v50p/nuc_package.cc	2018-05-23 15:19:02.306557326 +0100
 @@ -0,0 +1,834 @@
 +
 +//**.****|****.****|****.****|****.****|****.****|****.****|****.****|****.****|
@@ -925,7 +925,7 @@ diff -rupN darksusy-5.1.3/contrib/galprop/v50p/nuc_package.cc ../installed/darks
 +
 diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/access_SM.f90 ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/access_SM.f90
 --- darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/access_SM.f90	2013-02-11 06:11:43.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/access_SM.f90	2018-04-15 17:02:44.751922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/access_SM.f90	2018-05-23 15:18:58.102557401 +0100
 @@ -321,13 +321,13 @@ subroutine testBRSM(M)
     write(*,*)'calling the subroutines'
     write(*,*)'initialize_HiggsBounds and'
@@ -944,7 +944,7 @@ diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/access_SM.f90 ..
  !*********************************
 diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/channels.F90 ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/channels.F90
 --- darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/channels.F90	2013-02-11 06:11:43.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/channels.F90	2018-04-15 17:02:44.755922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/channels.F90	2018-05-23 15:18:58.102557401 +0100
 @@ -67,7 +67,7 @@ module channels
       case('TEV','LHC7')
        req= 0 * req
@@ -1086,11 +1086,9 @@ diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/channels.F90 ../
  
   end subroutine check_tables
   !************************************************************
-Binary files darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/Expt_tables/S95_t1.binary and ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/Expt_tables/S95_t1.binary differ
-Binary files darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/Expt_tables/S95_t2.binary and ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/Expt_tables/S95_t2.binary differ
 diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/extra_bits_for_SLHA.f90 ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/extra_bits_for_SLHA.f90
 --- darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/extra_bits_for_SLHA.f90	2013-02-11 06:11:43.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/extra_bits_for_SLHA.f90	2018-04-15 17:02:44.755922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/extra_bits_for_SLHA.f90	2018-05-23 15:18:58.102557401 +0100
 @@ -52,22 +52,22 @@ module extra_bits_for_SLHA
    !-------------------------------------------              
   
@@ -1130,7 +1128,7 @@ diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/extra_bits_for_S
      case(0)
 diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/HiggsBounds_subroutines.F90 ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/HiggsBounds_subroutines.F90
 --- darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/HiggsBounds_subroutines.F90	2013-02-11 06:11:43.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/HiggsBounds_subroutines.F90	2018-04-15 17:02:44.755922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/HiggsBounds_subroutines.F90	2018-05-23 15:18:58.106557401 +0100
 @@ -68,7 +68,7 @@ subroutine initialize_HiggsBounds(nHiggs
   np(Chiplus)=0! do not change this without contacting us first!
  
@@ -1363,7 +1361,7 @@ diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/HiggsBounds_subr
   if(debug)write(*,*)'finishing off...'                      ; call flush(6)
 diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/input.F90 ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/input.F90
 --- darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/input.F90	2013-02-11 06:11:43.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/input.F90	2018-04-15 17:02:44.755922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/input.F90	2018-05-23 15:18:58.106557401 +0100
 @@ -69,7 +69,7 @@ module input
     !haven't yet set whichanalyses,whichinput
     infile1=''
@@ -1680,7 +1678,7 @@ diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/input.F90 ../ins
     ! each file has the line number as the first column
 diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/interpolate.f90 ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/interpolate.f90
 --- darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/interpolate.f90	2013-02-11 06:11:43.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/interpolate.f90	2018-04-15 17:02:44.755922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/interpolate.f90	2018-05-23 15:18:58.106557401 +0100
 @@ -414,9 +414,9 @@ module interpolate
    !-------------------------------------------
  
@@ -1809,7 +1807,7 @@ diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/interpolate.f90 
  
 diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/makefile_darksusy.in ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/makefile_darksusy.in
 --- darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/makefile_darksusy.in	2015-04-07 10:23:05.000000000 +0100
-+++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/makefile_darksusy.in	2018-04-15 17:02:44.755922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/makefile_darksusy.in	2018-05-23 15:18:58.106557401 +0100
 @@ -106,10 +106,10 @@ OBJSsubroutines =  $(OBJSbasic) \
  default: HiggsBounds
  
@@ -1856,7 +1854,7 @@ diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/makefile_darksus
  	rm -f example_programs/example-SM_vs_4thGen
 diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/output.F90 ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/output.F90
 --- darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/output.F90	2013-02-11 06:11:43.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/output.F90	2018-04-15 17:02:44.759922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/output.F90	2018-05-23 15:18:58.106557401 +0100
 @@ -30,7 +30,7 @@ module output
    !-------------------------------------------
  
@@ -1917,7 +1915,7 @@ diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/output.F90 ../in
     select case(pr(n)%ttype)
 diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables.f90 ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables.f90
 --- darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables.f90	2013-02-11 06:11:43.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables.f90	2018-04-15 17:02:44.759922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables.f90	2018-05-23 15:18:58.106557401 +0100
 @@ -129,7 +129,7 @@ module S95tables
    do i=lbound(S95_t1,dim=1),ubound(S95_t1,dim=1)
     if(WhichColliderElement(S95_t1(i)%expt).eq.0)then
@@ -2345,7 +2343,7 @@ diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables.f90 ..
   end function S95_t1_or_S95_t2_elementnumberfromid
 diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables_type1.F90 ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables_type1.F90
 --- darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables_type1.F90	2013-02-11 06:11:43.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables_type1.F90	2018-04-15 17:02:44.759922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables_type1.F90	2018-05-23 15:18:58.110557401 +0100
 @@ -86,7 +86,7 @@ module S95tables_type1
     endif
    enddo
@@ -2366,7 +2364,7 @@ diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables_type1.
    ! do loop to read in S95 tables 
 diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables_type2.F90 ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables_type2.F90
 --- darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables_type2.F90	2013-02-11 06:11:43.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables_type2.F90	2018-04-15 17:02:44.759922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables_type2.F90	2018-05-23 15:18:58.110557401 +0100
 @@ -272,11 +272,11 @@ module S95tables_type2
  
       do k=lbound(file_id_arr,dim=1),ubound(file_id_arr,dim=1)
@@ -2499,7 +2497,7 @@ diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables_type2.
   end subroutine fill_t1_from_t2
 diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables_type3.F90 ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables_type3.F90
 --- darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables_type3.F90	2013-02-11 06:11:43.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables_type3.F90	2018-04-15 17:02:44.763922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables_type3.F90	2018-05-23 15:18:58.110557401 +0100
 @@ -249,7 +249,7 @@ module S95tables_type3
  
    ! checks we've filled the whole array
@@ -2805,7 +2803,7 @@ diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/S95tables_type3.
   
 diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/SLHA_manip.f90 ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/SLHA_manip.f90
 --- darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/SLHA_manip.f90	2013-02-11 06:11:43.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/SLHA_manip.f90	2018-04-15 17:02:44.763922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/SLHA_manip.f90	2018-05-23 15:18:58.110557401 +0100
 @@ -81,7 +81,7 @@ module SLHA_manip
    ! write(*,*)'hello block',names_of_blocks_and_decays(i)%id, &
    !  & trim(adjustl(names_of_blocks_and_decays(i)%line))
@@ -2893,7 +2891,7 @@ diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/SLHA_manip.f90 .
    rewind(fileid)
 diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/string_manip.f90 ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/string_manip.f90
 --- darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/string_manip.f90	2013-02-11 06:11:43.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/string_manip.f90	2018-04-15 17:02:44.763922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/string_manip.f90	2018-05-23 15:18:58.110557401 +0100
 @@ -12,9 +12,9 @@ contains
      !integer :: strlowa = 97
      !integer :: strlowz = 122
@@ -2952,7 +2950,7 @@ diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/string_manip.f90
    columns=''
 diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/theo_manip.f90 ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/theo_manip.f90
 --- darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/theo_manip.f90	2013-02-11 06:11:43.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/theo_manip.f90	2018-04-15 17:02:44.763922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/theo_manip.f90	2018-05-23 15:18:58.110557401 +0100
 @@ -36,7 +36,7 @@ module theo_manip
      call cp_from_g2
     case('hadr','part')
@@ -3065,7 +3063,7 @@ diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/theo_manip.f90 .
    else
 diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/theory_BRfunctions.F90 ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/theory_BRfunctions.F90
 --- darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/theory_BRfunctions.F90	2013-02-11 06:11:43.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/theory_BRfunctions.F90	2018-04-15 17:02:44.763922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/theory_BRfunctions.F90	2018-05-23 15:18:58.110557401 +0100
 @@ -56,7 +56,7 @@ module theory_BRfunctions
    
    ! checks we've filled the whole array
@@ -3075,10 +3073,9 @@ diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/theory_BRfunctio
    endif 
   
    col=7
-Binary files darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/Theory_tables/BRSM.binary and ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/Theory_tables/BRSM.binary differ
 diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/theory_XS_SM_functions.F90 ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/theory_XS_SM_functions.F90
 --- darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/theory_XS_SM_functions.F90	2013-02-11 06:11:43.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/theory_XS_SM_functions.F90	2018-04-15 17:02:44.763922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/theory_XS_SM_functions.F90	2018-05-23 15:18:58.110557401 +0100
 @@ -71,7 +71,7 @@ module theory_XS_SM_functions
         rangeok=.False.
        endif
@@ -3108,7 +3105,7 @@ diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/theory_XS_SM_fun
  
 diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/usefulbits.f90 ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/usefulbits.f90
 --- darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/usefulbits.f90	2013-02-11 06:11:43.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/usefulbits.f90	2018-04-15 17:02:44.763922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/usefulbits.f90	2018-05-23 15:18:58.114557401 +0100
 @@ -288,7 +288,7 @@ module usefulbits
        if(abs(value-array(i)).le.small) output = 1
      enddo
@@ -3192,7 +3189,7 @@ diff -rupN darksusy-5.1.3/contrib/HiggsBounds-3.8.1/HiggsBounds/usefulbits.f90 .
    deallocate(theo) !allocated in subroutine do_input  
 diff -rupN darksusy-5.1.3/contrib/isajet781-for-darksusy/aldata.f ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/aldata.f
 --- darksusy-5.1.3/contrib/isajet781-for-darksusy/aldata.f	2011-11-03 14:34:52.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/aldata.f	2018-04-15 17:02:44.767922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/aldata.f	2018-05-23 15:18:58.114557401 +0100
 @@ -155,8 +155,8 @@ C          LUXSET=.TRUE. after RLUXGO ha
       $GOWW(25,2),ALLWW(2),GOWMOD(25,MXGOJ)
        SAVE /Q1Q2/
@@ -3472,7 +3469,7 @@ diff -rupN darksusy-5.1.3/contrib/isajet781-for-darksusy/func_int.f ../installed
 -      END
 diff -rupN darksusy-5.1.3/contrib/isajet781-for-darksusy/gettot.f ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/gettot.f
 --- darksusy-5.1.3/contrib/isajet781-for-darksusy/gettot.f	2011-11-03 14:34:52.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/gettot.f	2018-04-15 17:02:44.767922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/gettot.f	2018-05-23 15:18:58.114557401 +0100
 @@ -77,8 +77,8 @@ C          Jet limits
        COMMON/IDRUN/IDVER,IDG(2),IEVT,IEVGEN
        SAVE /IDRUN/
@@ -3881,7 +3878,7 @@ diff -rupN darksusy-5.1.3/contrib/isajet781-for-darksusy/isared.f ../installed/d
 -      END
 diff -rupN darksusy-5.1.3/contrib/isajet781-for-darksusy/makefile.in ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/makefile.in
 --- darksusy-5.1.3/contrib/isajet781-for-darksusy/makefile.in	2011-11-03 14:34:52.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/makefile.in	2018-04-15 17:02:44.767922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/makefile.in	2018-05-23 15:18:58.114557401 +0100
 @@ -6,9 +6,6 @@
  FF=@F77@
  FOPT=@FOPT@
@@ -3925,7 +3922,7 @@ diff -rupN darksusy-5.1.3/contrib/isajet781-for-darksusy/makefile.in ../installe
  	rm -f *.o
 diff -rupN darksusy-5.1.3/contrib/isajet781-for-darksusy/prtevt.f ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/prtevt.f
 --- darksusy-5.1.3/contrib/isajet781-for-darksusy/prtevt.f	2011-11-03 14:34:52.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/prtevt.f	2018-04-15 17:02:44.767922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/prtevt.f	2018-05-23 15:18:58.114557401 +0100
 @@ -84,8 +84,8 @@ C
        COMMON/WSIG/SIGLLQ
        SAVE /WSIG/
@@ -3939,7 +3936,7 @@ diff -rupN darksusy-5.1.3/contrib/isajet781-for-darksusy/prtevt.f ../installed/d
  C          LABELS ARE CHARACTER*8
 diff -rupN darksusy-5.1.3/contrib/isajet781-for-darksusy/prtlim.f ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/prtlim.f
 --- darksusy-5.1.3/contrib/isajet781-for-darksusy/prtlim.f	2011-11-03 14:34:52.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/prtlim.f	2018-04-15 17:02:44.767922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/prtlim.f	2018-05-23 15:18:58.114557401 +0100
 @@ -79,8 +79,8 @@ C          KKGravity common
        COMMON/PRTOUT/NEVPRT,NJUMP
        SAVE /PRTOUT/
@@ -3953,7 +3950,7 @@ diff -rupN darksusy-5.1.3/contrib/isajet781-for-darksusy/prtlim.f ../installed/d
        PARAMETER (MXTYPE=8)
 diff -rupN darksusy-5.1.3/contrib/isajet781-for-darksusy/ranfgt.f ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/ranfgt.f
 --- darksusy-5.1.3/contrib/isajet781-for-darksusy/ranfgt.f	2011-11-03 14:34:52.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/ranfgt.f	2018-04-15 17:02:44.767922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/ranfgt.f	2018-05-23 15:18:58.114557401 +0100
 @@ -1,4 +1,4 @@
  C
 -      SUBROUTINE RANFGT(SEED)
@@ -3962,7 +3959,7 @@ diff -rupN darksusy-5.1.3/contrib/isajet781-for-darksusy/ranfgt.f ../installed/d
        END
 diff -rupN darksusy-5.1.3/contrib/isajet781-for-darksusy/ranfst.f ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/ranfst.f
 --- darksusy-5.1.3/contrib/isajet781-for-darksusy/ranfst.f	2011-11-03 14:34:52.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/ranfst.f	2018-04-15 17:02:44.767922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/ranfst.f	2018-05-23 15:18:58.114557401 +0100
 @@ -1,4 +1,4 @@
 -      SUBROUTINE RANFST(SEED)
 -      DOUBLE PRECISION SEED
@@ -3972,7 +3969,7 @@ diff -rupN darksusy-5.1.3/contrib/isajet781-for-darksusy/ranfst.f ../installed/d
        END
 diff -rupN darksusy-5.1.3/contrib/isajet781-for-darksusy/readin.f ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/readin.f
 --- darksusy-5.1.3/contrib/isajet781-for-darksusy/readin.f	2011-11-03 14:34:52.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/readin.f	2018-04-15 17:02:44.767922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/readin.f	2018-05-23 15:18:58.114557401 +0100
 @@ -73,8 +73,8 @@ C          KKGravity common
        COMMON/PRTOUT/NEVPRT,NJUMP
        SAVE /PRTOUT/
@@ -3995,7 +3992,7 @@ diff -rupN darksusy-5.1.3/contrib/isajet781-for-darksusy/readin.f ../installed/d
        DATA NLAP/1,2,3, 1,2,7 ,1,2,8, 1,3,5, 1,3,6, 1,3,7, 1,3,8, 1,5,7,
 diff -rupN darksusy-5.1.3/contrib/isajet781-for-darksusy/reset.f ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/reset.f
 --- darksusy-5.1.3/contrib/isajet781-for-darksusy/reset.f	2011-11-03 14:34:52.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/reset.f	2018-04-15 17:02:44.771922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/reset.f	2018-05-23 15:18:58.114557401 +0100
 @@ -84,8 +84,8 @@ C          Jet limits
       $GOWW(25,2),ALLWW(2),GOWMOD(25,MXGOJ)
        SAVE /Q1Q2/
@@ -4009,7 +4006,7 @@ diff -rupN darksusy-5.1.3/contrib/isajet781-for-darksusy/reset.f ../installed/da
  C          AMGLSS               = gluino mass
 diff -rupN darksusy-5.1.3/contrib/isajet781-for-darksusy/ssid.f ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/ssid.f
 --- darksusy-5.1.3/contrib/isajet781-for-darksusy/ssid.f	1970-01-01 01:00:00.000000000 +0100
-+++ ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/ssid.f	2018-04-15 17:02:44.771922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/isajet781-for-darksusy/ssid.f	2018-05-23 15:18:58.118557401 +0100
 @@ -0,0 +1,80 @@
 +      CHARACTER*5 FUNCTION SSID(ID)
 +C-----------------------------------------------------------------------
@@ -4093,7 +4090,7 @@ diff -rupN darksusy-5.1.3/contrib/isajet781-for-darksusy/ssid.f ../installed/dar
 +      END
 diff -rupN darksusy-5.1.3/contrib/TSPACK/makefile.in ../installed/darksusy/5.1.3/contrib/TSPACK/makefile.in
 --- darksusy-5.1.3/contrib/TSPACK/makefile.in	2013-02-10 06:43:34.000000000 +0000
-+++ ../installed/darksusy/5.1.3/contrib/TSPACK/makefile.in	2018-04-15 17:02:44.771922374 +0100
++++ ../installed/darksusy/5.1.3/contrib/TSPACK/makefile.in	2018-05-23 15:18:58.118557401 +0100
 @@ -9,8 +9,7 @@ FOPT=@FOPT@
  # Dependencies and libraries
  DINC=../../include
@@ -4121,7 +4118,7 @@ diff -rupN darksusy-5.1.3/contrib/TSPACK/makefile.in ../installed/darksusy/5.1.3
  	rm -f tspack.f *.o
 diff -rupN darksusy-5.1.3/HISTORY ../installed/darksusy/5.1.3/HISTORY
 --- darksusy-5.1.3/HISTORY	2015-12-22 20:08:40.000000000 +0000
-+++ ../installed/darksusy/5.1.3/HISTORY	2018-04-15 17:02:44.771922374 +0100
++++ ../installed/darksusy/5.1.3/HISTORY	2018-05-23 15:18:58.118557401 +0100
 @@ -3,6 +3,12 @@ Version history for DarkSUSY
  
  ====================================================== VERSION HISTORY
@@ -4137,7 +4134,7 @@ diff -rupN darksusy-5.1.3/HISTORY ../installed/darksusy/5.1.3/HISTORY
  
 diff -rupN darksusy-5.1.3/include/dsandwcom.h ../installed/darksusy/5.1.3/include/dsandwcom.h
 --- darksusy-5.1.3/include/dsandwcom.h	2010-08-06 09:27:44.000000000 +0100
-+++ ../installed/darksusy/5.1.3/include/dsandwcom.h	2018-04-15 17:02:44.771922374 +0100
++++ ../installed/darksusy/5.1.3/include/dsandwcom.h	2018-05-23 15:18:58.118557401 +0100
 @@ -23,7 +23,7 @@ c....dwcom - common block needed for the
        save /dwcom1/,/dwcom2/
  
@@ -4149,7 +4146,7 @@ diff -rupN darksusy-5.1.3/include/dsandwcom.h ../installed/darksusy/5.1.3/includ
  ***                                                                 ***
 diff -rupN darksusy-5.1.3/include/dsascom.h ../installed/darksusy/5.1.3/include/dsascom.h
 --- darksusy-5.1.3/include/dsascom.h	2008-06-23 22:39:47.000000000 +0100
-+++ ../installed/darksusy/5.1.3/include/dsascom.h	2018-04-15 17:02:44.771922374 +0100
++++ ../installed/darksusy/5.1.3/include/dsascom.h	2018-05-23 15:18:58.118557401 +0100
 @@ -44,10 +44,10 @@ c some roundoff terms
  
  c dsasdwdcossfsf final/intermediate state arrays/variables
@@ -4179,7 +4176,7 @@ diff -rupN darksusy-5.1.3/include/dsascom.h ../installed/darksusy/5.1.3/include/
  
 diff -rupN darksusy-5.1.3/include/dsdirver.h ../installed/darksusy/5.1.3/include/dsdirver.h
 --- darksusy-5.1.3/include/dsdirver.h	1970-01-01 01:00:00.000000000 +0100
-+++ ../installed/darksusy/5.1.3/include/dsdirver.h	2018-04-15 17:02:46.043922391 +0100
++++ ../installed/darksusy/5.1.3/include/dsdirver.h	2018-05-23 15:18:59.130557382 +0100
 @@ -0,0 +1,22 @@
 +*         -*- mode: fortran -*-
 +*######################################################################*
@@ -4191,7 +4188,7 @@ diff -rupN darksusy-5.1.3/include/dsdirver.h ../installed/darksusy/5.1.3/include
 +***         this piece of code is needed as a separate file          ***
 +***            the rest of the code 'includes' dsdirver.h            ***
 +c----------------------------------------------------------------------c
-+*** This file is created by config2.pl on Sun Apr 15 17:02:46 BST 2018
++*** This file is created by config2.pl on Wed May 23 15:18:59 BST 2018
 +
 +      character*5 dsver
 +      parameter(dsver='5.1.3')
@@ -4205,7 +4202,7 @@ diff -rupN darksusy-5.1.3/include/dsdirver.h ../installed/darksusy/5.1.3/include
 +************************** end of dsdirver.h ***************************
 diff -rupN darksusy-5.1.3/include/dsmssm.h ../installed/darksusy/5.1.3/include/dsmssm.h
 --- darksusy-5.1.3/include/dsmssm.h	2013-01-31 21:46:16.000000000 +0000
-+++ ../installed/darksusy/5.1.3/include/dsmssm.h	2018-04-15 17:02:44.771922374 +0100
++++ ../installed/darksusy/5.1.3/include/dsmssm.h	2018-05-23 15:18:58.118557401 +0100
 @@ -140,9 +140,12 @@ c
        complex*16 neunmx(4,4),chaumx(2,2),chavmx(2,2),
       & slulmx(3,3),sldlmx(6,3),sldrmx(6,3),
@@ -4222,7 +4219,7 @@ diff -rupN darksusy-5.1.3/include/dsmssm.h ../installed/darksusy/5.1.3/include/d
        common/sugrainput/m0var,mhfvar,a0var,tgbetavar,sgnmuvar
 diff -rupN darksusy-5.1.3/include/dsrdcom.h ../installed/darksusy/5.1.3/include/dsrdcom.h
 --- darksusy-5.1.3/include/dsrdcom.h	2010-08-06 09:27:44.000000000 +0100
-+++ ../installed/darksusy/5.1.3/include/dsrdcom.h	2018-04-15 17:02:44.771922374 +0100
++++ ../installed/darksusy/5.1.3/include/dsrdcom.h	2018-05-23 15:18:58.118557401 +0100
 @@ -58,9 +58,12 @@ c...rdlims
  c...rdswitch - switches
        integer thavint,rdprt
@@ -4239,7 +4236,7 @@ diff -rupN darksusy-5.1.3/include/dsrdcom.h ../installed/darksusy/5.1.3/include/
  
 diff -rupN darksusy-5.1.3/include/dswacom.h ../installed/darksusy/5.1.3/include/dswacom.h
 --- darksusy-5.1.3/include/dswacom.h	2015-12-20 21:43:06.000000000 +0000
-+++ ../installed/darksusy/5.1.3/include/dswacom.h	2018-04-15 17:02:44.771922374 +0100
++++ ../installed/darksusy/5.1.3/include/dswacom.h	2018-05-23 15:18:58.118557401 +0100
 @@ -18,30 +18,26 @@ c...to 52.
        integer wamax,walast(2),wanm
        parameter(wamax=6) ! number of tables to load simultaneously
@@ -4293,7 +4290,7 @@ diff -rupN darksusy-5.1.3/include/dswacom.h ../installed/darksusy/5.1.3/include/
  
 diff -rupN darksusy-5.1.3/include/FHCouplings.h ../installed/darksusy/5.1.3/include/FHCouplings.h
 --- darksusy-5.1.3/include/FHCouplings.h	1970-01-01 01:00:00.000000000 +0100
-+++ ../installed/darksusy/5.1.3/include/FHCouplings.h	2013-02-10 06:43:34.000000000 +0000
++++ ../installed/darksusy/5.1.3/include/FHCouplings.h	2018-05-23 15:18:58.118557401 +0100
 @@ -0,0 +1,149 @@
 +#if 0
 +	FHCouplings.h
@@ -4446,7 +4443,7 @@ diff -rupN darksusy-5.1.3/include/FHCouplings.h ../installed/darksusy/5.1.3/incl
 +
 diff -rupN darksusy-5.1.3/include/PDG.h ../installed/darksusy/5.1.3/include/PDG.h
 --- darksusy-5.1.3/include/PDG.h	1970-01-01 01:00:00.000000000 +0100
-+++ ../installed/darksusy/5.1.3/include/PDG.h	2013-02-10 06:43:34.000000000 +0000
++++ ../installed/darksusy/5.1.3/include/PDG.h	2018-05-23 15:18:58.118557401 +0100
 @@ -0,0 +1,79 @@
 +#if 0
 +	PDG.h
@@ -4529,7 +4526,7 @@ diff -rupN darksusy-5.1.3/include/PDG.h ../installed/darksusy/5.1.3/include/PDG.
 +
 diff -rupN darksusy-5.1.3/include/SLHADefs.h ../installed/darksusy/5.1.3/include/SLHADefs.h
 --- darksusy-5.1.3/include/SLHADefs.h	1970-01-01 01:00:00.000000000 +0100
-+++ ../installed/darksusy/5.1.3/include/SLHADefs.h	2013-02-10 06:43:34.000000000 +0000
++++ ../installed/darksusy/5.1.3/include/SLHADefs.h	2018-05-23 15:18:58.118557401 +0100
 @@ -0,0 +1,742 @@
 +#if 0
 +	SLHADefs.h
@@ -5275,7 +5272,7 @@ diff -rupN darksusy-5.1.3/include/SLHADefs.h ../installed/darksusy/5.1.3/include
 +#endif
 diff -rupN darksusy-5.1.3/include/SLHA.h ../installed/darksusy/5.1.3/include/SLHA.h
 --- darksusy-5.1.3/include/SLHA.h	1970-01-01 01:00:00.000000000 +0100
-+++ ../installed/darksusy/5.1.3/include/SLHA.h	2013-02-10 06:43:34.000000000 +0000
++++ ../installed/darksusy/5.1.3/include/SLHA.h	2018-05-23 15:18:58.118557401 +0100
 @@ -0,0 +1,17 @@
 +#if 0
 +	SLHA.h
@@ -5296,7 +5293,7 @@ diff -rupN darksusy-5.1.3/include/SLHA.h ../installed/darksusy/5.1.3/include/SLH
 +
 diff -rupN darksusy-5.1.3/makefile.in ../installed/darksusy/5.1.3/makefile.in
 --- darksusy-5.1.3/makefile.in	2015-04-07 10:23:05.000000000 +0100
-+++ ../installed/darksusy/5.1.3/makefile.in	2018-04-15 17:02:44.775922374 +0100
++++ ../installed/darksusy/5.1.3/makefile.in	2018-05-23 15:18:58.118557401 +0100
 @@ -60,7 +60,9 @@ HBDIR=@HIGGSBOUNDSDIR@
  SLHADIR=@SLHADIR@
  TSPACKDIR=@TSPACKDIR@
@@ -5396,7 +5393,7 @@ diff -rupN darksusy-5.1.3/makefile.in ../installed/darksusy/5.1.3/makefile.in
  		echo 'The install directory is different from DS_ROOT' ; \
 diff -rupN darksusy-5.1.3/misc/makefile.in ../installed/darksusy/5.1.3/misc/makefile.in
 --- darksusy-5.1.3/misc/makefile.in	2013-02-15 17:58:12.000000000 +0000
-+++ ../installed/darksusy/5.1.3/misc/makefile.in	2018-04-15 17:02:44.775922374 +0100
++++ ../installed/darksusy/5.1.3/misc/makefile.in	2018-05-23 15:18:58.118557401 +0100
 @@ -26,6 +26,10 @@ caprates : caprates.f $(LIB)/libdarksusy
  	$(FF) $(FOPT) $(INC) -L$(LIB) -o caprates caprates.f \
          -ldarksusy -lHB -lFH
@@ -5410,7 +5407,7 @@ diff -rupN darksusy-5.1.3/misc/makefile.in ../installed/darksusy/5.1.3/misc/make
          -ldarksusy -lHB -lFH
 diff -rupN darksusy-5.1.3/misc/oh2test.f ../installed/darksusy/5.1.3/misc/oh2test.f
 --- darksusy-5.1.3/misc/oh2test.f	1970-01-01 01:00:00.000000000 +0100
-+++ ../installed/darksusy/5.1.3/misc/oh2test.f	2018-04-15 17:02:44.775922374 +0100
++++ ../installed/darksusy/5.1.3/misc/oh2test.f	2018-05-23 15:18:58.118557401 +0100
 @@ -0,0 +1,294 @@
 +      program oh2test
 +c
@@ -5708,7 +5705,7 @@ diff -rupN darksusy-5.1.3/misc/oh2test.f ../installed/darksusy/5.1.3/misc/oh2tes
 +      end
 diff -rupN darksusy-5.1.3/share/DarkSUSY/tab_install.pl ../installed/darksusy/5.1.3/share/DarkSUSY/tab_install.pl
 --- darksusy-5.1.3/share/DarkSUSY/tab_install.pl	2008-04-11 10:31:28.000000000 +0100
-+++ ../installed/darksusy/5.1.3/share/DarkSUSY/tab_install.pl	2018-04-15 17:02:44.775922374 +0100
++++ ../installed/darksusy/5.1.3/share/DarkSUSY/tab_install.pl	2018-05-23 15:18:58.118557401 +0100
 @@ -12,7 +12,7 @@ if ($file =~ /.gz$/) {    # Convert asci
  #    } else {
  #	$type="d";
@@ -5720,7 +5717,7 @@ diff -rupN darksusy-5.1.3/share/DarkSUSY/tab_install.pl ../installed/darksusy/5.
      open(PROG,"|./ascii2bin") ||
 diff -rupN darksusy-5.1.3/src/as/dsaschicasea.f ../installed/darksusy/5.1.3/src/as/dsaschicasea.f
 --- darksusy-5.1.3/src/as/dsaschicasea.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/as/dsaschicasea.f	2018-04-15 17:02:44.775922374 +0100
++++ ../installed/darksusy/5.1.3/src/as/dsaschicasea.f	2018-05-23 15:18:58.122557400 +0100
 @@ -177,9 +177,13 @@ c....mass symbols used in form-code
            kchiu(k+2)=0
          enddo
@@ -5783,7 +5780,7 @@ diff -rupN darksusy-5.1.3/src/as/dsaschicasea.f ../installed/darksusy/5.1.3/src/
            kfers(i)=kcferd(i)
 diff -rupN darksusy-5.1.3/src/as/dsaschicaseb.f ../installed/darksusy/5.1.3/src/as/dsaschicaseb.f
 --- darksusy-5.1.3/src/as/dsaschicaseb.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/as/dsaschicaseb.f	2018-04-15 17:02:44.775922374 +0100
++++ ../installed/darksusy/5.1.3/src/as/dsaschicaseb.f	2018-05-23 15:18:58.122557400 +0100
 @@ -171,9 +171,13 @@ c....mass symbols used in form-code
            kchiu(k+2)=0
          enddo
@@ -5845,7 +5842,7 @@ diff -rupN darksusy-5.1.3/src/as/dsaschicaseb.f ../installed/darksusy/5.1.3/src/
          goto 200
 diff -rupN darksusy-5.1.3/src/as/dsaschicasec.f ../installed/darksusy/5.1.3/src/as/dsaschicasec.f
 --- darksusy-5.1.3/src/as/dsaschicasec.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/as/dsaschicasec.f	2018-04-15 17:02:44.779922374 +0100
++++ ../installed/darksusy/5.1.3/src/as/dsaschicasec.f	2018-05-23 15:18:58.122557400 +0100
 @@ -227,9 +227,13 @@ c....mass symbols used in form-code
            kchiu(k+2)=0
          enddo
@@ -5907,7 +5904,7 @@ diff -rupN darksusy-5.1.3/src/as/dsaschicasec.f ../installed/darksusy/5.1.3/src/
            kfers(i)=kcferd(i)
 diff -rupN darksusy-5.1.3/src/as/dsaschicased.f ../installed/darksusy/5.1.3/src/as/dsaschicased.f
 --- darksusy-5.1.3/src/as/dsaschicased.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/as/dsaschicased.f	2018-04-15 17:02:44.779922374 +0100
++++ ../installed/darksusy/5.1.3/src/as/dsaschicased.f	2018-05-23 15:18:58.122557400 +0100
 @@ -194,9 +194,13 @@ c....mass symbols used in form-code
            kchiu(k+2)=0
          enddo
@@ -5969,7 +5966,7 @@ diff -rupN darksusy-5.1.3/src/as/dsaschicased.f ../installed/darksusy/5.1.3/src/
          goto 400
 diff -rupN darksusy-5.1.3/src/as/dsasdwdcossfchi.f ../installed/darksusy/5.1.3/src/as/dsasdwdcossfchi.f
 --- darksusy-5.1.3/src/as/dsasdwdcossfchi.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/as/dsasdwdcossfchi.f	2018-04-15 17:02:44.779922374 +0100
++++ ../installed/darksusy/5.1.3/src/as/dsasdwdcossfchi.f	2018-05-23 15:18:58.122557400 +0100
 @@ -15,6 +15,8 @@
  ***   final state quarks in selected cases, June 2006, Jan 2007      ***
  *** modified: Piero Ullio to include a new labelling of states,      ***
@@ -6556,7 +6553,7 @@ diff -rupN darksusy-5.1.3/src/as/dsasdwdcossfchi.f ../installed/darksusy/5.1.3/s
            write(*,*) 'DS: wrong ciaux value =',ciaux
 diff -rupN darksusy-5.1.3/src/as/dsasdwdcossfsf.f ../installed/darksusy/5.1.3/src/as/dsasdwdcossfsf.f
 --- darksusy-5.1.3/src/as/dsasdwdcossfsf.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/as/dsasdwdcossfsf.f	2018-04-15 17:02:44.779922374 +0100
++++ ../installed/darksusy/5.1.3/src/as/dsasdwdcossfsf.f	2018-05-23 15:18:58.122557400 +0100
 @@ -19,6 +19,11 @@
  *** modified: Piero Ullio to include mixing in fermion final states  ***
  ***   and a new labelling of states                                  ***
@@ -8142,7 +8139,7 @@ diff -rupN darksusy-5.1.3/src/as/dsasdwdcossfsf.f ../installed/darksusy/5.1.3/sr
                wok=.false.
 diff -rupN darksusy-5.1.3/src/as/dsasgbhb.f ../installed/darksusy/5.1.3/src/as/dsasgbhb.f
 --- darksusy-5.1.3/src/as/dsasgbhb.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/as/dsasgbhb.f	2018-04-15 17:02:44.783922374 +0100
++++ ../installed/darksusy/5.1.3/src/as/dsasgbhb.f	2018-05-23 15:18:58.126557400 +0100
 @@ -20,6 +20,9 @@
  *** added by Mia Schelke Jan 2007                          ***
  *** modified: Piero Ullio to include a new labelling of    ***
@@ -8261,7 +8258,7 @@ diff -rupN darksusy-5.1.3/src/as/dsasgbhb.f ../installed/darksusy/5.1.3/src/as/d
  *****
 diff -rupN darksusy-5.1.3/src/dd/dsdddn1.f ../installed/darksusy/5.1.3/src/dd/dsdddn1.f
 --- darksusy-5.1.3/src/dd/dsdddn1.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/dd/dsdddn1.f	2018-04-15 17:02:44.783922374 +0100
++++ ../installed/darksusy/5.1.3/src/dd/dsdddn1.f	2018-05-23 15:18:58.126557400 +0100
 @@ -15,7 +15,8 @@ c
        mx2=mx*mx/scale
        delta=4.d0*mq2*ms2-(mq2+ms2-mx2)**2
@@ -8274,7 +8271,7 @@ diff -rupN darksusy-5.1.3/src/dd/dsdddn1.f ../installed/darksusy/5.1.3/src/dd/ds
        endif
 diff -rupN darksusy-5.1.3/src/dd/dsdddn2.f ../installed/darksusy/5.1.3/src/dd/dsdddn2.f
 --- darksusy-5.1.3/src/dd/dsdddn2.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/dd/dsdddn2.f	2018-04-15 17:02:44.783922374 +0100
++++ ../installed/darksusy/5.1.3/src/dd/dsdddn2.f	2018-05-23 15:18:58.126557400 +0100
 @@ -15,7 +15,8 @@ c
        mx2=mx*mx/scale
        delta=4.d0*mq2*ms2-(mq2+ms2-mx2)**2
@@ -8287,7 +8284,7 @@ diff -rupN darksusy-5.1.3/src/dd/dsdddn2.f ../installed/darksusy/5.1.3/src/dd/ds
        endif
 diff -rupN darksusy-5.1.3/src/dd/dsdddn3.f ../installed/darksusy/5.1.3/src/dd/dsdddn3.f
 --- darksusy-5.1.3/src/dd/dsdddn3.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/dd/dsdddn3.f	2018-04-15 17:02:44.783922374 +0100
++++ ../installed/darksusy/5.1.3/src/dd/dsdddn3.f	2018-05-23 15:18:58.126557400 +0100
 @@ -15,7 +15,8 @@ c
        mx2=mx*mx/scale
        delta=4.d0*mq2*ms2-(mq2+ms2-mx2)**2
@@ -8300,7 +8297,7 @@ diff -rupN darksusy-5.1.3/src/dd/dsdddn3.f ../installed/darksusy/5.1.3/src/dd/ds
        endif
 diff -rupN darksusy-5.1.3/src/dd/dsdddn4.f ../installed/darksusy/5.1.3/src/dd/dsdddn4.f
 --- darksusy-5.1.3/src/dd/dsdddn4.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/dd/dsdddn4.f	2018-04-15 17:02:44.783922374 +0100
++++ ../installed/darksusy/5.1.3/src/dd/dsdddn4.f	2018-05-23 15:18:58.126557400 +0100
 @@ -15,7 +15,8 @@ c
        mx2=mx*mx/scale
        delta=4.d0*mq2*ms2-(mq2+ms2-mx2)**2
@@ -8313,7 +8310,7 @@ diff -rupN darksusy-5.1.3/src/dd/dsdddn4.f ../installed/darksusy/5.1.3/src/dd/ds
        endif
 diff -rupN darksusy-5.1.3/src/dd/dsddgpgn.f ../installed/darksusy/5.1.3/src/dd/dsddgpgn.f
 --- darksusy-5.1.3/src/dd/dsddgpgn.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/dd/dsddgpgn.f	2018-04-15 17:02:44.783922374 +0100
++++ ../installed/darksusy/5.1.3/src/dd/dsddgpgn.f	2018-05-23 15:18:58.126557400 +0100
 @@ -310,7 +310,7 @@ c
            ds = ds
       &       + 0.25*(dsabsq(gl(ksqd(i),kx,ks))+
@@ -8334,7 +8331,7 @@ diff -rupN darksusy-5.1.3/src/dd/dsddgpgn.f ../installed/darksusy/5.1.3/src/dd/d
        gpa = du*delu+dd*deld+ds*dels ! in gev^-4
 diff -rupN darksusy-5.1.3/src/ep/dsepmstable.f ../installed/darksusy/5.1.3/src/ep/dsepmstable.f
 --- darksusy-5.1.3/src/ep/dsepmstable.f	2006-06-19 15:36:02.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/ep/dsepmstable.f	2018-04-15 17:02:44.783922374 +0100
++++ ../installed/darksusy/5.1.3/src/ep/dsepmstable.f	2018-05-23 15:18:58.126557400 +0100
 @@ -12,7 +12,8 @@
  
        include 'dsepcom.h'
@@ -8356,7 +8353,7 @@ diff -rupN darksusy-5.1.3/src/ep/dsepmstable.f ../installed/darksusy/5.1.3/src/e
 +
 diff -rupN darksusy-5.1.3/src/hm/dshmudfearthtab.f ../installed/darksusy/5.1.3/src/hm/dshmudfearthtab.f
 --- darksusy-5.1.3/src/hm/dshmudfearthtab.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/hm/dshmudfearthtab.f	2018-04-15 17:02:44.783922374 +0100
++++ ../installed/darksusy/5.1.3/src/hm/dshmudfearthtab.f	2018-05-23 15:18:58.126557400 +0100
 @@ -5,12 +5,12 @@
  *** and then lines with two columns each  with u and u*DF(u).
  *** u should be in units of km/s and u*DF(u) (or f(u)/u) in units
@@ -8414,7 +8411,7 @@ diff -rupN darksusy-5.1.3/src/hm/dshmudfearthtab.f ../installed/darksusy/5.1.3/s
        return
 diff -rupN darksusy-5.1.3/src/hm/dshmudftab.f ../installed/darksusy/5.1.3/src/hm/dshmudftab.f
 --- darksusy-5.1.3/src/hm/dshmudftab.f	2012-07-15 22:04:50.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/hm/dshmudftab.f	2018-04-15 17:02:44.783922374 +0100
++++ ../installed/darksusy/5.1.3/src/hm/dshmudftab.f	2018-05-23 15:18:58.126557400 +0100
 @@ -5,12 +5,12 @@
  *** and then lines with two columns each  with u and u*DF(u).
  *** u should be in units of km/s and u*DF(u) (or f(u)/u) in units
@@ -8454,7 +8451,7 @@ diff -rupN darksusy-5.1.3/src/hm/dshmudftab.f ../installed/darksusy/5.1.3/src/hm
        return
 diff -rupN darksusy-5.1.3/src/ib/dsIBffdxdy.f ../installed/darksusy/5.1.3/src/ib/dsIBffdxdy.f
 --- darksusy-5.1.3/src/ib/dsIBffdxdy.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/ib/dsIBffdxdy.f	2018-04-15 17:02:44.783922374 +0100
++++ ../installed/darksusy/5.1.3/src/ib/dsIBffdxdy.f	2018-05-23 15:18:58.126557400 +0100
 @@ -259,14 +259,14 @@ c       endif
  
  c...check that result is positive
@@ -8480,7 +8477,7 @@ diff -rupN darksusy-5.1.3/src/ib/dsIBffdxdy.f ../installed/darksusy/5.1.3/src/ib
  
 diff -rupN darksusy-5.1.3/src/ib/dsIBfsrdxdy.f ../installed/darksusy/5.1.3/src/ib/dsIBfsrdxdy.f
 --- darksusy-5.1.3/src/ib/dsIBfsrdxdy.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/ib/dsIBfsrdxdy.f	2018-04-15 17:02:44.783922374 +0100
++++ ../installed/darksusy/5.1.3/src/ib/dsIBfsrdxdy.f	2018-05-23 15:18:58.126557400 +0100
 @@ -62,10 +62,10 @@ c... from a full analytical calculation
  
  c...check that result is positive
@@ -8498,7 +8495,7 @@ diff -rupN darksusy-5.1.3/src/ib/dsIBfsrdxdy.f ../installed/darksusy/5.1.3/src/i
        endif
 diff -rupN darksusy-5.1.3/src/ib/dsIBhhdxdy.f ../installed/darksusy/5.1.3/src/ib/dsIBhhdxdy.f
 --- darksusy-5.1.3/src/ib/dsIBhhdxdy.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/ib/dsIBhhdxdy.f	2018-04-15 17:02:44.783922374 +0100
++++ ../installed/darksusy/5.1.3/src/ib/dsIBhhdxdy.f	2018-05-23 15:18:58.126557400 +0100
 @@ -80,15 +80,15 @@ c...import full IB expression for |M|**2
  
  c...check that the result is positive
@@ -8526,7 +8523,7 @@ diff -rupN darksusy-5.1.3/src/ib/dsIBhhdxdy.f ../installed/darksusy/5.1.3/src/ib
  
 diff -rupN darksusy-5.1.3/src/ib/dsIBwhdxdy.f ../installed/darksusy/5.1.3/src/ib/dsIBwhdxdy.f
 --- darksusy-5.1.3/src/ib/dsIBwhdxdy.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/ib/dsIBwhdxdy.f	2018-04-15 17:02:44.783922374 +0100
++++ ../installed/darksusy/5.1.3/src/ib/dsIBwhdxdy.f	2018-05-23 15:18:58.126557400 +0100
 @@ -205,14 +205,14 @@ c       endif
  
  c...check that result is positive
@@ -8552,7 +8549,7 @@ diff -rupN darksusy-5.1.3/src/ib/dsIBwhdxdy.f ../installed/darksusy/5.1.3/src/ib
  
 diff -rupN darksusy-5.1.3/src/ib/dsIBwwdxdy.f ../installed/darksusy/5.1.3/src/ib/dsIBwwdxdy.f
 --- darksusy-5.1.3/src/ib/dsIBwwdxdy.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/ib/dsIBwwdxdy.f	2018-04-15 17:02:44.787922374 +0100
++++ ../installed/darksusy/5.1.3/src/ib/dsIBwwdxdy.f	2018-05-23 15:18:58.126557400 +0100
 @@ -137,14 +137,14 @@ c       endif
  
  c...check that result is positive
@@ -8607,7 +8604,7 @@ diff -rupN darksusy-5.1.3/src/ini/dsdirname.c.in ../installed/darksusy/5.1.3/src
 -}
 diff -rupN darksusy-5.1.3/src/ini/dsinit.f ../installed/darksusy/5.1.3/src/ini/dsinit.f
 --- darksusy-5.1.3/src/ini/dsinit.f	2013-02-10 06:43:34.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/ini/dsinit.f	2018-04-15 17:02:44.787922374 +0100
++++ ../installed/darksusy/5.1.3/src/ini/dsinit.f	2018-05-23 15:18:58.130557400 +0100
 @@ -299,16 +299,27 @@ c... numbers are conventional, no physic
        ivtype(ksnue)=11
        ivtype(kse1)=12
@@ -8717,7 +8714,7 @@ diff -rupN darksusy-5.1.3/src/ini/dsvername.c.in ../installed/darksusy/5.1.3/src
 -}
 diff -rupN darksusy-5.1.3/src/ini/makefile ../installed/darksusy/5.1.3/src/ini/makefile
 --- darksusy-5.1.3/src/ini/makefile	1970-01-01 01:00:00.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/ini/makefile	2018-04-15 17:02:50.627922454 +0100
++++ ../installed/darksusy/5.1.3/src/ini/makefile	2018-05-23 15:19:02.790557317 +0100
 @@ -0,0 +1,37 @@
 +# Makefile for ini directory
 +# Author: Joakim Edsjo, edsjo@physto.se
@@ -8758,7 +8755,7 @@ diff -rupN darksusy-5.1.3/src/ini/makefile ../installed/darksusy/5.1.3/src/ini/m
 +	$(FC) $(FFLAGS) $< -o $@
 diff -rupN darksusy-5.1.3/src/ini/makefile.in ../installed/darksusy/5.1.3/src/ini/makefile.in
 --- darksusy-5.1.3/src/ini/makefile.in	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/ini/makefile.in	2018-04-15 17:02:44.787922374 +0100
++++ ../installed/darksusy/5.1.3/src/ini/makefile.in	2018-05-23 15:18:58.130557400 +0100
 @@ -22,7 +22,7 @@ dswacom.h
  vpath %.h $(DINC)
  
@@ -8770,7 +8767,7 @@ diff -rupN darksusy-5.1.3/src/ini/makefile.in ../installed/darksusy/5.1.3/src/in
  
 diff -rupN darksusy-5.1.3/src/makefile.in ../installed/darksusy/5.1.3/src/makefile.in
 --- darksusy-5.1.3/src/makefile.in	2015-04-07 10:23:05.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/makefile.in	2018-04-15 17:02:44.787922374 +0100
++++ ../installed/darksusy/5.1.3/src/makefile.in	2018-05-23 15:18:58.130557400 +0100
 @@ -10,14 +10,16 @@
  #### DO NOT CHANGE ANYTHING BELOW THIS LINE ###
  ###############################################
@@ -8819,7 +8816,7 @@ diff -rupN darksusy-5.1.3/src/makefile.in ../installed/darksusy/5.1.3/src/makefi
  
 diff -rupN darksusy-5.1.3/src/nt/dsntearthdens.f ../installed/darksusy/5.1.3/src/nt/dsntearthdens.f
 --- darksusy-5.1.3/src/nt/dsntearthdens.f	2006-06-19 22:24:29.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/nt/dsntearthdens.f	2018-04-15 17:02:44.787922374 +0100
++++ ../installed/darksusy/5.1.3/src/nt/dsntearthdens.f	2018-05-23 15:18:58.130557400 +0100
 @@ -52,7 +52,7 @@ c      end
        include 'dsearth.h'
  
@@ -8831,7 +8828,7 @@ diff -rupN darksusy-5.1.3/src/nt/dsntearthdens.f ../installed/darksusy/5.1.3/src
       &  219.99d0,220.0d0,399.99d0,400.0d0,500.0d0,
 diff -rupN darksusy-5.1.3/src/nt/dsntearthmass.f ../installed/darksusy/5.1.3/src/nt/dsntearthmass.f
 --- darksusy-5.1.3/src/nt/dsntearthmass.f	2006-06-19 15:36:02.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/nt/dsntearthmass.f	2018-04-15 17:02:44.787922374 +0100
++++ ../installed/darksusy/5.1.3/src/nt/dsntearthmass.f	2018-05-23 15:18:58.130557400 +0100
 @@ -12,7 +12,7 @@
        implicit none
  
@@ -8843,7 +8840,7 @@ diff -rupN darksusy-5.1.3/src/nt/dsntearthmass.f ../installed/darksusy/5.1.3/src
       &  878140.0d0,1128140.0d0,1228140.0d0,1228150.0d0,1378140.0d0,
 diff -rupN darksusy-5.1.3/src/nt/dsntearthpot.f ../installed/darksusy/5.1.3/src/nt/dsntearthpot.f
 --- darksusy-5.1.3/src/nt/dsntearthpot.f	2006-06-19 15:36:02.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/nt/dsntearthpot.f	2018-04-15 17:02:44.787922374 +0100
++++ ../installed/darksusy/5.1.3/src/nt/dsntearthpot.f	2018-05-23 15:18:58.130557400 +0100
 @@ -16,7 +16,8 @@
        real*8 radius(42),pot(42),ppl,r,gn,dsntearthmass,
       &  dsntearthpotint
@@ -8856,7 +8853,7 @@ diff -rupN darksusy-5.1.3/src/nt/dsntearthpot.f ../installed/darksusy/5.1.3/src/
        data first/.true./
 diff -rupN darksusy-5.1.3/src/nt/dsntmuonyield.f ../installed/darksusy/5.1.3/src/nt/dsntmuonyield.f
 --- darksusy-5.1.3/src/nt/dsntmuonyield.f	2013-01-31 21:46:16.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/nt/dsntmuonyield.f	2018-04-15 17:02:44.787922374 +0100
++++ ../installed/darksusy/5.1.3/src/nt/dsntmuonyield.f	2018-05-23 15:18:58.130557400 +0100
 @@ -78,21 +78,16 @@ c      call wirate(6,6,1)
           stop
        endif
@@ -8881,7 +8878,7 @@ diff -rupN darksusy-5.1.3/src/nt/dsntmuonyield.f ../installed/darksusy/5.1.3/src
  
 diff -rupN darksusy-5.1.3/src/nt/dsntsuncdens.f ../installed/darksusy/5.1.3/src/nt/dsntsuncdens.f
 --- darksusy-5.1.3/src/nt/dsntsuncdens.f	2006-06-19 22:30:05.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/nt/dsntsuncdens.f	2018-04-15 17:02:44.787922374 +0100
++++ ../installed/darksusy/5.1.3/src/nt/dsntsuncdens.f	2018-05-23 15:18:58.130557400 +0100
 @@ -1,6 +1,6 @@
  ***********************************************************************
  *** This routine uses a derived column density from the BP2000 model
@@ -8908,7 +8905,7 @@ diff -rupN darksusy-5.1.3/src/nt/dsntsuncdens.f ../installed/darksusy/5.1.3/src/
          ti=1
 diff -rupN darksusy-5.1.3/src/nt/dsntsundens.f ../installed/darksusy/5.1.3/src/nt/dsntsundens.f
 --- darksusy-5.1.3/src/nt/dsntsundens.f	2006-06-19 22:24:29.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/nt/dsntsundens.f	2018-04-15 17:02:44.787922374 +0100
++++ ../installed/darksusy/5.1.3/src/nt/dsntsundens.f	2018-05-23 15:18:58.130557400 +0100
 @@ -7,7 +7,7 @@
  *** ApJ 555 (2001) 990.
  *** The mass fractions for heavier elements are from N. Grevesse and
@@ -8938,7 +8935,7 @@ diff -rupN darksusy-5.1.3/src/nt/dsntsundens.f ../installed/darksusy/5.1.3/src/n
  
 diff -rupN darksusy-5.1.3/src/nt/dsntsunmass.f ../installed/darksusy/5.1.3/src/nt/dsntsunmass.f
 --- darksusy-5.1.3/src/nt/dsntsunmass.f	2006-06-19 15:36:02.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/nt/dsntsunmass.f	2018-04-15 17:02:44.787922374 +0100
++++ ../installed/darksusy/5.1.3/src/nt/dsntsunmass.f	2018-05-23 15:18:58.130557400 +0100
 @@ -7,7 +7,7 @@
  *** ApJ 555 (2001) 990.
  *** The mass fractions for heavier elements are from N. Grevesse and
@@ -8959,7 +8956,7 @@ diff -rupN darksusy-5.1.3/src/nt/dsntsunmass.f ../installed/darksusy/5.1.3/src/n
        call dsntsunread
 diff -rupN darksusy-5.1.3/src/nt/dsntsunmfrac.f ../installed/darksusy/5.1.3/src/nt/dsntsunmfrac.f
 --- darksusy-5.1.3/src/nt/dsntsunmfrac.f	2006-06-19 15:36:02.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/nt/dsntsunmfrac.f	2018-04-15 17:02:44.787922374 +0100
++++ ../installed/darksusy/5.1.3/src/nt/dsntsunmfrac.f	2018-05-23 15:18:58.130557400 +0100
 @@ -8,7 +8,7 @@
  *** ApJ 555 (2001) 990.
  *** The mass fractions for heavier elements are from N. Grevesse and
@@ -8981,7 +8978,7 @@ diff -rupN darksusy-5.1.3/src/nt/dsntsunmfrac.f ../installed/darksusy/5.1.3/src/
        call dsntsunread
 diff -rupN darksusy-5.1.3/src/nt/dsntsunne2x.f ../installed/darksusy/5.1.3/src/nt/dsntsunne2x.f
 --- darksusy-5.1.3/src/nt/dsntsunne2x.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/nt/dsntsunne2x.f	2018-04-15 17:02:44.791922374 +0100
++++ ../installed/darksusy/5.1.3/src/nt/dsntsunne2x.f	2018-05-23 15:18:58.130557400 +0100
 @@ -15,7 +15,7 @@
        include 'dsmpconst.h'
  
@@ -9002,7 +8999,7 @@ diff -rupN darksusy-5.1.3/src/nt/dsntsunne2x.f ../installed/darksusy/5.1.3/src/n
  
 diff -rupN darksusy-5.1.3/src/nt/dsntsunne.f ../installed/darksusy/5.1.3/src/nt/dsntsunne.f
 --- darksusy-5.1.3/src/nt/dsntsunne.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/nt/dsntsunne.f	2018-04-15 17:02:44.791922374 +0100
++++ ../installed/darksusy/5.1.3/src/nt/dsntsunne.f	2018-05-23 15:18:58.130557400 +0100
 @@ -15,7 +15,7 @@
        include 'dsmpconst.h'
  
@@ -9023,7 +9020,7 @@ diff -rupN darksusy-5.1.3/src/nt/dsntsunne.f ../installed/darksusy/5.1.3/src/nt/
  
 diff -rupN darksusy-5.1.3/src/nt/dsntsunpot.f ../installed/darksusy/5.1.3/src/nt/dsntsunpot.f
 --- darksusy-5.1.3/src/nt/dsntsunpot.f	2006-06-19 15:36:02.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/nt/dsntsunpot.f	2018-04-15 17:02:44.791922374 +0100
++++ ../installed/darksusy/5.1.3/src/nt/dsntsunpot.f	2018-05-23 15:18:58.130557400 +0100
 @@ -1,6 +1,6 @@
  ***********************************************************************
  *** This routine uses a derived potential from the BP2000 model
@@ -9052,7 +9049,7 @@ diff -rupN darksusy-5.1.3/src/nt/dsntsunpot.f ../installed/darksusy/5.1.3/src/nt
  c...Check if data file is loaded
 diff -rupN darksusy-5.1.3/src/nt/dsntsunx2z.f ../installed/darksusy/5.1.3/src/nt/dsntsunx2z.f
 --- darksusy-5.1.3/src/nt/dsntsunx2z.f	2006-06-19 22:30:05.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/nt/dsntsunx2z.f	2018-04-15 17:02:44.791922374 +0100
++++ ../installed/darksusy/5.1.3/src/nt/dsntsunx2z.f	2018-05-23 15:18:58.130557400 +0100
 @@ -29,12 +29,12 @@
        include 'dssun.h'
        real*8 x,rpl,dsntsuncdens
@@ -9070,7 +9067,7 @@ diff -rupN darksusy-5.1.3/src/nt/dsntsunx2z.f ../installed/darksusy/5.1.3/src/nt
          ti=1
 diff -rupN darksusy-5.1.3/src/nt/dsntsunz2x.f ../installed/darksusy/5.1.3/src/nt/dsntsunz2x.f
 --- darksusy-5.1.3/src/nt/dsntsunz2x.f	2006-06-19 22:30:05.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/nt/dsntsunz2x.f	2018-04-15 17:02:44.791922374 +0100
++++ ../installed/darksusy/5.1.3/src/nt/dsntsunz2x.f	2018-05-23 15:18:58.130557400 +0100
 @@ -7,7 +7,7 @@
  ***        the column density is either of p or n or the total
  ***        and the totals are stored in cd_sun
@@ -9107,7 +9104,7 @@ diff -rupN darksusy-5.1.3/src/nt/dsntsunz2x.f ../installed/darksusy/5.1.3/src/nt
  
 diff -rupN darksusy-5.1.3/src/rd/dsrdaddpt.f ../installed/darksusy/5.1.3/src/rd/dsrdaddpt.f
 --- darksusy-5.1.3/src/rd/dsrdaddpt.f	2008-09-09 20:51:09.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/rd/dsrdaddpt.f	2018-04-15 17:02:44.791922374 +0100
++++ ../installed/darksusy/5.1.3/src/rd/dsrdaddpt.f	2018-05-23 15:18:58.130557400 +0100
 @@ -1,10 +1,12 @@
 -      subroutine dsrdaddpt(wrate,pres,deltap)
 +      subroutine dsrdaddpt(wrate,pres,deltap,deltapminr)
@@ -9157,7 +9154,7 @@ diff -rupN darksusy-5.1.3/src/rd/dsrdaddpt.f ../installed/darksusy/5.1.3/src/rd/
        enddo
 diff -rupN darksusy-5.1.3/src/rd/dsrdcom.f ../installed/darksusy/5.1.3/src/rd/dsrdcom.f
 --- darksusy-5.1.3/src/rd/dsrdcom.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/rd/dsrdcom.f	2018-04-15 17:02:44.791922374 +0100
++++ ../installed/darksusy/5.1.3/src/rd/dsrdcom.f	2018-05-23 15:18:58.134557400 +0100
 @@ -14,5 +14,12 @@ c...0.996195d0 - 5 degrees, 0.999048d0 -
        data pdivr,dpres/2.0d0,0.5d0/
        data nlow,nhigh,npres,nthup,cthtest,spltest
@@ -9173,7 +9170,7 @@ diff -rupN darksusy-5.1.3/src/rd/dsrdcom.f ../installed/darksusy/5.1.3/src/rd/ds
  
 diff -rupN darksusy-5.1.3/src/rd/dsrdens.f ../installed/darksusy/5.1.3/src/rd/dsrdens.f
 --- darksusy-5.1.3/src/rd/dsrdens.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/rd/dsrdens.f	2018-04-15 18:09:11.719976925 +0100
++++ ../installed/darksusy/5.1.3/src/rd/dsrdens.f	2018-05-23 15:18:58.134557400 +0100
 @@ -1,5 +1,5 @@
        subroutine dsrdens(wrate,npart,kpart,mgev,dof,nrs,rm,rw,
 -     &  nt,tm,oh2,tf,ierr,iwar)
@@ -9226,7 +9223,7 @@ diff -rupN darksusy-5.1.3/src/rd/dsrdens.f ../installed/darksusy/5.1.3/src/rd/ds
  c------------------------------------------ determine integration limits
 diff -rupN darksusy-5.1.3/src/rd/dsrdspline.f ../installed/darksusy/5.1.3/src/rd/dsrdspline.f
 --- darksusy-5.1.3/src/rd/dsrdspline.f	2013-01-31 21:46:16.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/rd/dsrdspline.f	2018-04-15 17:02:44.791922374 +0100
++++ ../installed/darksusy/5.1.3/src/rd/dsrdspline.f	2018-05-23 15:18:58.134557400 +0100
 @@ -57,7 +57,8 @@ c...jump out of loop
     11 continue
  
@@ -9239,7 +9236,7 @@ diff -rupN darksusy-5.1.3/src/rd/dsrdspline.f ../installed/darksusy/5.1.3/src/rd
  
 diff -rupN darksusy-5.1.3/src/rd/dsrdtab.f ../installed/darksusy/5.1.3/src/rd/dsrdtab.f
 --- darksusy-5.1.3/src/rd/dsrdtab.f	2010-08-06 09:27:44.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/rd/dsrdtab.f	2018-04-15 18:19:27.835985355 +0100
++++ ../installed/darksusy/5.1.3/src/rd/dsrdtab.f	2018-05-23 15:18:58.134557400 +0100
 @@ -1,9 +1,12 @@
 -      subroutine dsrdtab(wrate,xmin)
 +      subroutine dsrdtab(wrate,xmin,fast)
@@ -9454,7 +9451,7 @@ diff -rupN darksusy-5.1.3/src/rd/dsrdtab.f ../installed/darksusy/5.1.3/src/rd/ds
            pp2=pp(indx(i+1))
 diff -rupN darksusy-5.1.3/src/rn/dsrdomega.f ../installed/darksusy/5.1.3/src/rn/dsrdomega.f
 --- darksusy-5.1.3/src/rn/dsrdomega.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/rn/dsrdomega.f	2018-04-15 17:02:44.791922374 +0100
++++ ../installed/darksusy/5.1.3/src/rn/dsrdomega.f	2018-05-23 15:18:58.134557400 +0100
 @@ -12,11 +12,25 @@
  ***            3 - include only coannihilations between sfermions
  ***                and the lightest neutralino
@@ -9565,7 +9562,7 @@ diff -rupN darksusy-5.1.3/src/rn/dsrdomega.f ../installed/darksusy/5.1.3/src/rn/
           nfc=2
 diff -rupN darksusy-5.1.3/src/slha/dsfromslha.F ../installed/darksusy/5.1.3/src/slha/dsfromslha.F
 --- darksusy-5.1.3/src/slha/dsfromslha.F	2013-01-31 21:46:16.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/slha/dsfromslha.F	2018-04-15 17:02:44.791922374 +0100
++++ ../installed/darksusy/5.1.3/src/slha/dsfromslha.F	2018-05-23 15:18:58.134557400 +0100
 @@ -8,6 +8,7 @@
  ***         More options on how to treat redundant information, e.g.
  ***         should Yukawas from SLHA file be used instead of letting
@@ -9602,7 +9599,7 @@ diff -rupN darksusy-5.1.3/src/slha/dsfromslha.F ../installed/darksusy/5.1.3/src/
 -
 diff -rupN darksusy-5.1.3/src/su/dsorder_flavour.f ../installed/darksusy/5.1.3/src/su/dsorder_flavour.f
 --- darksusy-5.1.3/src/su/dsorder_flavour.f	1970-01-01 01:00:00.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/su/dsorder_flavour.f	2018-04-15 17:02:44.795922374 +0100
++++ ../installed/darksusy/5.1.3/src/su/dsorder_flavour.f	2018-05-23 15:18:58.134557400 +0100
 @@ -0,0 +1,277 @@
 +*******************************************************************************
 +*** This routine orders all sfermions according to flavour. For sleptons,   ***
@@ -9883,7 +9880,7 @@ diff -rupN darksusy-5.1.3/src/su/dsorder_flavour.f ../installed/darksusy/5.1.3/s
 +
 diff -rupN darksusy-5.1.3/src/su/dssuconst_yukawa_running.f ../installed/darksusy/5.1.3/src/su/dssuconst_yukawa_running.f
 --- darksusy-5.1.3/src/su/dssuconst_yukawa_running.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/su/dssuconst_yukawa_running.f	2018-04-15 17:02:44.795922374 +0100
++++ ../installed/darksusy/5.1.3/src/su/dssuconst_yukawa_running.f	2018-05-23 15:18:58.134557400 +0100
 @@ -20,6 +20,9 @@ c=======================================
        mscale=2.d0*mass(lsp)
        alph3=dsralph3(mscale)
@@ -9896,7 +9893,7 @@ diff -rupN darksusy-5.1.3/src/su/dssuconst_yukawa_running.f ../installed/darksus
        yukawa(ktau)= aux*dsrmq(mscale,ktau)/cosbe
 diff -rupN darksusy-5.1.3/src/su/dsvertx1.f ../installed/darksusy/5.1.3/src/su/dsvertx1.f
 --- darksusy-5.1.3/src/su/dsvertx1.f	2011-11-04 23:48:05.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/su/dsvertx1.f	2018-04-15 17:02:44.795922374 +0100
++++ ../installed/darksusy/5.1.3/src/su/dsvertx1.f	2018-05-23 15:18:58.134557400 +0100
 @@ -616,11 +616,11 @@ c       neutrinos
            gjll=-(g2weak*neunmx(j,2)-gyweak*neunmx(j,1))/sqrt(2.0d0)
            do k=1,3
@@ -9915,7 +9912,7 @@ diff -rupN darksusy-5.1.3/src/su/dsvertx1.f ../installed/darksusy/5.1.3/src/su/d
  c       charged leptons
 diff -rupN darksusy-5.1.3/src/su/makefile.in ../installed/darksusy/5.1.3/src/su/makefile.in
 --- darksusy-5.1.3/src/su/makefile.in	2013-01-31 21:46:16.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/su/makefile.in	2018-04-15 17:02:44.795922374 +0100
++++ ../installed/darksusy/5.1.3/src/su/makefile.in	2018-05-23 15:18:58.134557400 +0100
 @@ -32,7 +32,7 @@ dsrmq4loop.f dssfesct.f dsspectrum.f dss
  dssuconst_ckm.f dssuconst_couplings.f dssuconst_higgs.f \
  dssuconst_yukawa.f dssuconst_yukawa_running.f dssusy.f dsvertx.f \
@@ -9927,7 +9924,7 @@ diff -rupN darksusy-5.1.3/src/su/makefile.in ../installed/darksusy/5.1.3/src/su/
  
 diff -rupN darksusy-5.1.3/src/ucmh/dspbh_limits.f ../installed/darksusy/5.1.3/src/ucmh/dspbh_limits.f
 --- darksusy-5.1.3/src/ucmh/dspbh_limits.f	2015-04-05 02:53:52.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/ucmh/dspbh_limits.f	2018-04-15 17:02:44.795922374 +0100
++++ ../installed/darksusy/5.1.3/src/ucmh/dspbh_limits.f	2018-05-23 15:18:58.134557400 +0100
 @@ -8,15 +8,15 @@
  !Output:    betamax   maximum allowed value of beta
  
@@ -9959,7 +9956,7 @@ diff -rupN darksusy-5.1.3/src/ucmh/dspbh_limits.f ../installed/darksusy/5.1.3/sr
  
 diff -rupN darksusy-5.1.3/src/ucmh/dsucmh_aontsq.f ../installed/darksusy/5.1.3/src/ucmh/dsucmh_aontsq.f
 --- darksusy-5.1.3/src/ucmh/dsucmh_aontsq.f	2015-04-07 14:12:14.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/ucmh/dsucmh_aontsq.f	2018-04-15 17:02:44.795922374 +0100
++++ ../installed/darksusy/5.1.3/src/ucmh/dsucmh_aontsq.f	2018-05-23 15:18:58.134557400 +0100
 @@ -6,37 +6,42 @@
  !Date: 2011
  !
@@ -10015,7 +10012,7 @@ diff -rupN darksusy-5.1.3/src/ucmh/dsucmh_aontsq.f ../installed/darksusy/5.1.3/s
  
 diff -rupN darksusy-5.1.3/src/wa/dswadydth.f ../installed/darksusy/5.1.3/src/wa/dswadydth.f
 --- darksusy-5.1.3/src/wa/dswadydth.f	2015-12-20 21:43:06.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/wa/dswadydth.f	2018-04-15 17:02:44.795922374 +0100
++++ ../installed/darksusy/5.1.3/src/wa/dswadydth.f	2018-05-23 15:18:58.134557400 +0100
 @@ -8,7 +8,6 @@
        real*8 function dswadydth(cth, phim0,phim1,phim2,phie0,phieth,phithm,
       & phichi,phiwh,phifk,phifv)
@@ -10026,7 +10023,7 @@ diff -rupN darksusy-5.1.3/src/wa/dswadydth.f ../installed/darksusy/5.1.3/src/wa/
  
 diff -rupN darksusy-5.1.3/src/wa/dswaemean.f ../installed/darksusy/5.1.3/src/wa/dswaemean.f
 --- darksusy-5.1.3/src/wa/dswaemean.f	2009-03-30 13:08:08.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/wa/dswaemean.f	2018-04-15 17:02:44.795922374 +0100
++++ ../installed/darksusy/5.1.3/src/wa/dswaemean.f	2018-05-23 15:18:58.134557400 +0100
 @@ -8,8 +8,6 @@
  
        real*8 function dswaemean(e0,m0,m1,m2)
@@ -10038,7 +10035,7 @@ diff -rupN darksusy-5.1.3/src/wa/dswaemean.f ../installed/darksusy/5.1.3/src/wa/
  
 diff -rupN darksusy-5.1.3/src/wa/dswaifind.f ../installed/darksusy/5.1.3/src/wa/dswaifind.f
 --- darksusy-5.1.3/src/wa/dswaifind.f	2008-04-07 22:27:47.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/wa/dswaifind.f	2018-04-15 17:02:44.795922374 +0100
++++ ../installed/darksusy/5.1.3/src/wa/dswaifind.f	2018-05-23 15:18:58.134557400 +0100
 @@ -6,7 +6,6 @@
        subroutine dswaifind(value,array,ipl,ii,imin,imax)
        implicit none
@@ -10049,7 +10046,7 @@ diff -rupN darksusy-5.1.3/src/wa/dswaifind.f ../installed/darksusy/5.1.3/src/wa/
        integer imin,imax,i,inew,imint,imaxt,iold,ii
 diff -rupN darksusy-5.1.3/src/wa/dswainit.f ../installed/darksusy/5.1.3/src/wa/dswainit.f
 --- darksusy-5.1.3/src/wa/dswainit.f	2013-01-27 15:37:53.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/wa/dswainit.f	2018-04-15 17:02:44.795922374 +0100
++++ ../installed/darksusy/5.1.3/src/wa/dswainit.f	2018-05-23 15:18:58.138557400 +0100
 @@ -271,9 +271,9 @@ c     &            k,mfi
  
  c...Create mixed tables, differential in energy, integrated in theta
@@ -10072,7 +10069,7 @@ diff -rupN darksusy-5.1.3/src/wa/dswainit.f ../installed/darksusy/5.1.3/src/wa/d
  c      data wabase/'we-res-may2012'/
 diff -rupN darksusy-5.1.3/src/wa/dswayield.f ../installed/darksusy/5.1.3/src/wa/dswayield.f
 --- darksusy-5.1.3/src/wa/dswayield.f	2011-05-24 09:54:48.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/wa/dswayield.f	2018-04-15 17:02:44.795922374 +0100
++++ ../installed/darksusy/5.1.3/src/wa/dswayield.f	2018-05-23 15:18:58.138557400 +0100
 @@ -59,8 +59,6 @@
        real*8 function dswayield(mneu,e,theta,wh,kind,type,istat)
        implicit none
@@ -10084,7 +10081,7 @@ diff -rupN darksusy-5.1.3/src/wa/dswayield.f ../installed/darksusy/5.1.3/src/wa/
  
 diff -rupN darksusy-5.1.3/src/wa/dswayieldf.f ../installed/darksusy/5.1.3/src/wa/dswayieldf.f
 --- darksusy-5.1.3/src/wa/dswayieldf.f	2015-12-20 21:43:06.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/wa/dswayieldf.f	2018-04-15 17:02:44.795922374 +0100
++++ ../installed/darksusy/5.1.3/src/wa/dswayieldf.f	2018-05-23 15:18:58.138557400 +0100
 @@ -52,11 +52,13 @@
  
        real*8 function dswayieldf(mwimp,e,theta,chi,wh,kind,
@@ -10124,7 +10121,7 @@ diff -rupN darksusy-5.1.3/src/wa/dswayieldf.f ../installed/darksusy/5.1.3/src/wa
        dswayieldf=0.0d0
 diff -rupN darksusy-5.1.3/src/wa/dswayieldfth.f ../installed/darksusy/5.1.3/src/wa/dswayieldfth.f
 --- darksusy-5.1.3/src/wa/dswayieldfth.f	2015-12-20 21:43:06.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/wa/dswayieldfth.f	2018-04-15 17:02:44.795922374 +0100
++++ ../installed/darksusy/5.1.3/src/wa/dswayieldfth.f	2018-05-23 15:18:58.138557400 +0100
 @@ -6,7 +6,7 @@
  *****************************************************************************
  
@@ -10157,11 +10154,11 @@ diff -rupN darksusy-5.1.3/src/wa/dswayieldfth.f ../installed/darksusy/5.1.3/src/
        endif
 diff -rupN darksusy-5.1.3/src/wa/dswayield_int.f ../installed/darksusy/5.1.3/src/wa/dswayield_int.f
 --- darksusy-5.1.3/src/wa/dswayield_int.f	2015-12-20 21:43:06.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/wa/dswayield_int.f	2018-04-15 17:02:44.799922374 +0100
++++ ../installed/darksusy/5.1.3/src/wa/dswayield_int.f	2018-05-23 15:20:19.582555942 +0100
 @@ -1,5 +1,5 @@
        real*8 function dswayield_int(f,a,b,phichi,phiwh,phim0,phim1,phim2,
 -     & phie0,phieth,phithm,phifk,phifv)        
-+     & phie0,phieth,phithm,phifk,phifv,waerror)        
++     & phie0,phieth,phithm,phifk,phifv,waerror)
  
  c_______________________________________________________________________
  c  integrate function f between a and b
@@ -10170,7 +10167,8 @@ diff -rupN darksusy-5.1.3/src/wa/dswayield_int.f ../installed/darksusy/5.1.3/src
  c=======================================================================
        implicit none
 -      include 'dswacom.h'
-       real*8 f,a,b,tot,eps,st,os,ost,del,sum,x
+-      real*8 f,a,b,tot,eps,st,os,ost,del,sum,x
++      real*8 f,a,b,tot,epsabs,eps,st,os,ost,del,sum,x
        real*8 phim0,phim1,phim2,phie0,phieth,phithm
        integer phichi,phiwh,phifk,phifv   ! phiwh=1 - sun, 2 - earth
 -      integer jmax,it,l,j,nfcn,jdid
@@ -10178,10 +10176,19 @@ diff -rupN darksusy-5.1.3/src/wa/dswayield_int.f ../installed/darksusy/5.1.3/src
        external f
  c      parameter (a=-1.0,b=1.0,eps=1.0d-4,jmax=20)
 -      parameter (eps=1.0d-2,jmax=30)  ! je change in eps ps change in jmax
-+      parameter (eps=1.0d-2,jmax=22)  ! je change in eps ps change in jmax
++      parameter (epsabs=1d5, eps=1.0d-2, jmax=20)  ! je change in eps, ps added epsabs
        dswayield_int=0.d0
        del=b-a
        ost=0.5*del*(f(a,phim0,phim1,phim2,phie0,phieth,phithm,phichi,phiwh,phifk,phifv)+
+@@ -41,7 +40,7 @@ c      parameter (a=-1.0,b=1.0,eps=1.0d-
+         st=0.5*(st+del*sum)
+         tot=(4.0*st-ost)/3.0
+         jdid=j
+-        if (abs(tot-os).le.eps*abs(os)) then
++        if (abs(tot-os).le.eps*abs(os) .or. abs(tot).le.epsabs) then
+            dswayield_int=tot
+            return
+         endif
 @@ -50,8 +49,11 @@ c      parameter (a=-1.0,b=1.0,eps=1.0d-
  c        type *,'jdid',jdid,' os',os, 'ost',ost
        enddo
@@ -10197,7 +10204,7 @@ diff -rupN darksusy-5.1.3/src/wa/dswayield_int.f ../installed/darksusy/5.1.3/src
        end
 diff -rupN darksusy-5.1.3/src/wa/dswayieldone.f ../installed/darksusy/5.1.3/src/wa/dswayieldone.f
 --- darksusy-5.1.3/src/wa/dswayieldone.f	2013-01-31 21:46:16.000000000 +0000
-+++ ../installed/darksusy/5.1.3/src/wa/dswayieldone.f	2018-04-15 17:02:44.799922374 +0100
++++ ../installed/darksusy/5.1.3/src/wa/dswayieldone.f	2018-05-23 15:18:58.138557400 +0100
 @@ -105,16 +105,16 @@
  *****************************************************************************
  
@@ -10354,7 +10361,7 @@ diff -rupN darksusy-5.1.3/src/wa/dswayieldone.f ../installed/darksusy/5.1.3/src/
  
 diff -rupN darksusy-5.1.3/src/wa/dswayields2.f ../installed/darksusy/5.1.3/src/wa/dswayields2.f
 --- darksusy-5.1.3/src/wa/dswayields2.f	2009-05-08 09:54:47.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/wa/dswayields2.f	2018-04-15 17:02:44.799922374 +0100
++++ ../installed/darksusy/5.1.3/src/wa/dswayields2.f	2018-05-23 15:18:58.138557400 +0100
 @@ -8,14 +8,14 @@
  *****************************************************************************
  
@@ -10643,7 +10650,7 @@ diff -rupN darksusy-5.1.3/src/wa/dswayields2.f ../installed/darksusy/5.1.3/src/w
        endif
 diff -rupN darksusy-5.1.3/src/wa/dswayields3.f ../installed/darksusy/5.1.3/src/wa/dswayields3.f
 --- darksusy-5.1.3/src/wa/dswayields3.f	2009-05-08 09:54:47.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/wa/dswayields3.f	2018-04-15 17:02:44.799922374 +0100
++++ ../installed/darksusy/5.1.3/src/wa/dswayields3.f	2018-05-23 15:18:58.138557400 +0100
 @@ -8,14 +8,14 @@
  *****************************************************************************
  
@@ -10932,7 +10939,7 @@ diff -rupN darksusy-5.1.3/src/wa/dswayields3.f ../installed/darksusy/5.1.3/src/w
        endif
 diff -rupN darksusy-5.1.3/src/wa/dswayields4.f ../installed/darksusy/5.1.3/src/wa/dswayields4.f
 --- darksusy-5.1.3/src/wa/dswayields4.f	2009-05-08 09:54:47.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/wa/dswayields4.f	2018-04-15 17:02:44.799922374 +0100
++++ ../installed/darksusy/5.1.3/src/wa/dswayields4.f	2018-05-23 15:18:58.138557400 +0100
 @@ -8,7 +8,7 @@
  *****************************************************************************
  
@@ -11074,7 +11081,7 @@ diff -rupN darksusy-5.1.3/src/wa/dswayields4.f ../installed/darksusy/5.1.3/src/w
        endif
 diff -rupN darksusy-5.1.3/src/wa/dswayields.f ../installed/darksusy/5.1.3/src/wa/dswayields.f
 --- darksusy-5.1.3/src/wa/dswayields.f	2009-05-08 09:54:47.000000000 +0100
-+++ ../installed/darksusy/5.1.3/src/wa/dswayields.f	2018-04-15 17:02:44.799922374 +0100
++++ ../installed/darksusy/5.1.3/src/wa/dswayields.f	2018-05-23 15:18:58.138557400 +0100
 @@ -8,14 +8,14 @@
  *****************************************************************************
  


### PR DESCRIPTION
This modifies src/wa/dswayield_int.f in DarkSUSY 5.1.3 to introduce an absolute precision.

To test this, just nuke darksusy and rebuild with the new patch.  If the usual tests run OK (SingletDM.yaml, etc), then merge to master.  The fix can then be merged into personal feature branches from the master.
