### PR TITLE
Fix for unexpected behaviour of the MAP_TO_CAPABILITY macro

### DIFF
--- a/Models/include/gambit/Models/model_macros.hpp
+++ b/Models/include/gambit/Models/model_macros.hpp
@@ -278,6 +278,9 @@
                                                                                \
       }                                                                        \
                                                                                \
+      /* Make the functor exclusive to this model and its descendants */       \
+      CORE_ALLOW_MODEL(MODEL,PARAMETER,MODEL)                                  \
+                                                                               \
     }                                                                          \
                                                                                \
   }                                                                            \


### PR DESCRIPTION
I noticed a somehow unexpected behaviour of the function which is created  by the `MAP_TO_CAPABILITY` macro.

Let's say we have two models `ModelA` and `ModelB` which are independent of each other (i.e. there is no parent-child nor friend relationship between these models) and they both have a common parameter `common_par` which is directly forwarded as a capability with the same name via the `MAP_TO_CAPABILITY` macro, such that other capabilities which require this common parameter as a dependence do not depend on the actual models which can provide the parameter `common_par`. In doing so it can be avoided to update the list of allowed models for these capabilities in case a model `ModelC` is added which also provides `common_par`.

The problem I observed is the following: Suppose I have a scan of `ModelA` and somewhen in the dependency tree the capability `some_par` is required, then the dependency resolver will complain about the ambiguity of the capability `some_par` since it apparently assumes that both implementation of `some_par` in `ModelA` and `ModelB` are valid and can be activated even though `ModelB` is not in use.

Having a look into `Models/include/gambit/Models/model_macros.hpp`, I noticed that in the definition of the `MAP_TO_CAPABILITY` macro, there is no explicit model restriction to the actual model it will be used in, such that these functions could in principle work with all possible models. Therefore the depresolver complains.

I think that this is a typo and that it explicitly should only work with the model it is defined in. Other macros in that file actually have this restriction, thus I assume that it was also intended there but was forgotten so far, since this problem has never ocurred so far.

In this fix I added the `CORE_ALLOW_MODEL` macro to the definition of `MAP_TO_CAPABILITY` such that it is now possible to run the scan described above without the ambiguity.