### PR TITLE
Enable scientific notation for integer types in yaml file

### DIFF
--- a/Utils/include/gambit/Utils/yaml_options.hpp
+++ b/Utils/include/gambit/Utils/yaml_options.hpp
@@ -231,20 +231,34 @@ namespace Gambit
       /// then performs checks before casting to an integer type.
       template<class TYPE>
       TYPE safeIntegerTypeCast(const std::string& s) const {
-        const double d = std::stod(s);
-        if (d != std::floor(d))
-        {
+        try {
+          const double d = std::stod(s);
+          if (d != std::floor(d))
+          {
+            std::ostringstream os;
+            os << "Provided value " << d << " as option in the yaml file does not represent an integer.";
+            utils_error().raise(LOCAL_INFO, os.str());
+          }
+          if (std::numeric_limits<TYPE>::max() < d or std::numeric_limits<TYPE>::min() > d)
+          {
+            std::ostringstream os;
+            os << "Provided value " << d << " as option in the yaml file does not fit into the implemented integer type.";
+            utils_error().raise(LOCAL_INFO, os.str());
+          }
+          return static_cast<TYPE>(d);
+        }
+        catch (const std::out_of_range& e) {
           std::ostringstream os;
-          os << "Provided value " << d << " as option in the yaml file does not represent an integer.";
+          os << "Out of range error: " << e.what() << "\n";
+          os << "Provided value " << s << " as option in the yaml file does not fit into double.";
           utils_error().raise(LOCAL_INFO, os.str());
         }
-        if (std::numeric_limits<TYPE>::max() < d or std::numeric_limits<TYPE>::min() > d)
-        {
+        catch (const std::invalid_argument& e) {
           std::ostringstream os;
-          os << "Provided value " << d << " as option in the yaml file does not fit into the implemented integer type.";
+          os << "Invalid argument: " << e.what() << "\n";
+          os << "Provided value " << s << " as option in the yaml file can not be interpreted as double.";
           utils_error().raise(LOCAL_INFO, os.str());
         }
-        return static_cast<TYPE>(d);
       }
 
   };


### PR DESCRIPTION
Addresses #46.

This is a prototype for this feature. Unfortunately I can not run any ColliderBit yaml file on the Core_development branch to test this.

@anderkve I get. 
```
 FATAL ERROR

GAMBIT has exited with fatal exception: GAMBIT error
ERROR: A problem has been raised by the dependency resolver subsystem.
None of the vertex candidates for
unimproved_MSSM_spectrum (Spectrum), required by MSSM_spectrum (Spectrum) [make_MSSM_precision_spectrum_none, PrecisionBit]
fulfills all rules in the YAML file.
Please check your YAML file for contradictory rules.
Raised at: line 1286 in function Gambit::DRes::VertexID Gambit::DRes::DependencyResolver::resolveDependencyFromRules(const VertexID&, const sspair&) of /home/mapr/CLionProjects/gambitgit/Core/src/depresolver.cpp.
```
My guess is I have to switch to the ColliderBit branch to test, this but I thought I ask first.

