### PR TITLE
Downgrade -std=c++17 to -std=c++14 when using icpc 19.x.x and pybind11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,9 +264,10 @@ foreach(OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES} )
     set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${mylibdir} )
 endforeach()
 
-# Check if we are using 2019 intel compilers together with pybind11, and forbid the use of C++17 if so.
-if(HAVE_PYBIND11 AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 18.0.6)
+# Check if we are using 2019 intel compilers or gcc 6.1 or 6.2 together with pybind11, and forbid the use of C++17 if so.
+if(HAVE_PYBIND11)
+  if(("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 18.0.6) OR
+     ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.6 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.3))
     set(PERMIT_CXX17_CHECK FALSE)
   else()
     set(PERMIT_CXX17_CHECK TRUE)


### PR DESCRIPTION
The PR addresses the issue #147 seen when trying to compile GAMBIT with pybind11 and without ROOT on Prometheus, using 2019 intel compilers.  The changes here force a downgrade of the C++ standard when using intel 2019 compilers and pybind11, from C++17 to C++14.