### PR TITLE
Add missing include to avoid random build failures.

### DIFF
--- a/Utils/src/yaml_node_utility.cpp
+++ b/Utils/src/yaml_node_utility.cpp
@@ -16,6 +16,7 @@
 ///  *********************************************
 
 #include "gambit/Utils/yaml_node_utility.hpp"
+#include <cstring>
 
 namespace Gambit 
 {


### PR DESCRIPTION
Solution for the easy part of #162 for the current master build issues.