### PR TITLE
Add Github continuous integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master, gitlab-ci ]
   pull_request:
     branches: [ master ]
+  schedule:
+    - cron:  '* * * * 1'
 
 jobs:
   gambit_build:


### PR DESCRIPTION
Adding Github CI configuration -- build is successful for Ubuntu, some issues for Python2 and Fedora at present, but I think those may be real issues. There are now also a couple of tests of bundled YAML files, as well as Andrew's BATS tests (currently failing). It'd be good to get this off the specialist branch and into the master and selected dev branches.