### PR TITLE
Trying to fix problems with dependency resolution when running CLASS & energy injection models

### DIFF
--- a/Backends/include/gambit/Backends/frontends/classy_exo_2_7_0.hpp
+++ b/Backends/include/gambit/Backends/frontends/classy_exo_2_7_0.hpp
@@ -11,7 +11,7 @@
 ///  \author Janina Renk
 ///          (janina.renk@fysik.su.se)
 ///  \date 2019 June
-///  \date 2020 July
+///  \date 2020 July, Aug
 ///
 ///  \author Sanjay Bloor
 ///          (sanjay.bloor12@imperial.ac.uk)
@@ -55,7 +55,7 @@ LOAD_LIBRARY
   BE_CONV_FUNCTION(class_get_scale_independent_growth_factor,   double, (double), "class_get_scale_independent_growth_factor")
   BE_CONV_FUNCTION(class_get_scale_independent_growth_factor_f,   double, (double), "class_get_scale_independent_growth_factor_f")
 
-  BE_INI_DEPENDENCY(classy_input_params, Classy_input)
+  BE_INI_DEPENDENCY(classy_parameters_EnergyInjection, Classy_input)
 
 
 #endif

--- a/Backends/include/gambit/Backends/frontends/classy_exo_2_7_2.hpp
+++ b/Backends/include/gambit/Backends/frontends/classy_exo_2_7_2.hpp
@@ -11,7 +11,7 @@
 ///  \author Janina Renk
 ///          (janina.renk@fysik.su.se)
 ///  \date 2019 June
-///  \date 2020 July
+///  \date 2020 July, Aug
 ///
 ///  \author Sanjay Bloor
 ///          (sanjay.bloor12@imperial.ac.uk)
@@ -56,7 +56,7 @@ LOAD_LIBRARY
   BE_CONV_FUNCTION(class_get_scale_independent_growth_factor,   double, (double), "class_get_scale_independent_growth_factor")
   BE_CONV_FUNCTION(class_get_scale_independent_growth_factor_f,   double, (double), "class_get_scale_independent_growth_factor_f")
 
-  BE_INI_DEPENDENCY(classy_input_params, Classy_input)
+  BE_INI_DEPENDENCY(classy_parameters_EnergyInjection, Classy_input)
 
 #endif
 

--- a/Backends/src/frontends/classy_exo_2_7_0.cpp
+++ b/Backends/src/frontends/classy_exo_2_7_0.cpp
@@ -11,6 +11,7 @@
 ///  \author Janina Renk
 ///          (janina.renk@fysik.su.se)
 ///  \date 2019 June
+///  \date 2020 June, Aug
 ///
 ///  \author Sanjay Bloor
 ///          (sanjay.bloor12@imperial.ac.uk)
@@ -358,7 +359,13 @@ BE_INI_FUNCTION
     static int max_errors = 100;
 
     // get input for CLASS run set by CosmoBit
-    Classy_input input_container= *Dep::classy_input_params;
+    // If annihilating or decaying DM models are scanned, get the input dictionary
+    // with the energy injection related parameters. If not, simply get the 
+    // standard parameters set in 'classy_parameters'
+    Classy_input input_container = *Dep::classy_parameters_EnergyInjection;
+
+    
+    // extract python input dictionary
     pybind11::dict cosmo_input_dict = input_container.get_input_dict();
 
     // Check whether the energy injection tables have changed.

--- a/Backends/src/frontends/classy_exo_2_7_2.cpp
+++ b/Backends/src/frontends/classy_exo_2_7_2.cpp
@@ -11,6 +11,7 @@
 ///  \author Janina Renk
 ///          (janina.renk@fysik.su.se)
 ///  \date 2019 June
+///  \date 2020 June, Aug
 ///
 ///  \author Sanjay Bloor
 ///          (sanjay.bloor12@imperial.ac.uk)
@@ -357,7 +358,12 @@ BE_INI_FUNCTION
     static int max_errors = 100;
 
     // get input for CLASS run set by CosmoBit
-    Classy_input input_container= *Dep::classy_input_params;
+    // If annihilating or decaying DM models are scanned, get the input dictionary
+    // with the energy injection related parameters. If not, simply get the 
+    // standard parameters set in 'classy_parameters'
+    Classy_input input_container = *Dep::classy_parameters_EnergyInjection;
+    
+    // extract python input dictionary
     pybind11::dict cosmo_input_dict = input_container.get_input_dict();
 
     // Check whether the energy injection tables have changed.

--- a/CosmoBit/include/gambit/CosmoBit/CosmoBit_rollcall.hpp
+++ b/CosmoBit/include/gambit/CosmoBit/CosmoBit_rollcall.hpp
@@ -184,7 +184,7 @@ START_MODULE
     DEPENDENCY(classy_MPLike_input, pybind11::dict)
     DEPENDENCY(classy_NuMasses_Nur_input, pybind11::dict)
     DEPENDENCY(classy_primordial_input, pybind11::dict)
-    MODEL_CONDITIONAL_DEPENDENCY(classy_parameters_EnergyInjection, pybind11::dict, AnnihilatingDM_general, DecayingDM_general)
+    //MODEL_CONDITIONAL_DEPENDENCY(classy_parameters_EnergyInjection, pybind11::dict, AnnihilatingDM_general, DecayingDM_general)
     MODEL_CONDITIONAL_DEPENDENCY(classy_PlanckLike_input, pybind11::dict, cosmo_nuisance_Planck_lite,cosmo_nuisance_Planck_TTTEEE,cosmo_nuisance_Planck_TT,plik_dx11dr2_HM_v18_TT)
     #undef FUNCTION
   #undef CAPABILITY
@@ -227,15 +227,22 @@ START_MODULE
   #define CAPABILITY classy_parameters_EnergyInjection
   START_CAPABILITY
     #define FUNCTION set_classy_parameters_EnergyInjection_AnnihilatingDM
-    START_FUNCTION(pybind11::dict)
-    ALLOW_MODELS(AnnihilatingDM_general)
+    START_FUNCTION(Classy_input)
+    DEPENDENCY(classy_input_params,Classy_input)
+    ALLOW_MODEL(AnnihilatingDM_general)
     DEPENDENCY(energy_injection_efficiency, DarkAges::Energy_injection_efficiency_table)
     #undef FUNCTION
 
     #define FUNCTION set_classy_parameters_EnergyInjection_DecayingDM
-    START_FUNCTION(pybind11::dict)
-    ALLOW_MODELS(DecayingDM_general)
+    START_FUNCTION(Classy_input)
+    DEPENDENCY(classy_input_params,Classy_input)
+    ALLOW_MODEL(DecayingDM_general)
     DEPENDENCY(energy_injection_efficiency, DarkAges::Energy_injection_efficiency_table)
+    #undef FUNCTION
+
+    #define FUNCTION set_classy_parameters_no_EnergyInjection
+    START_FUNCTION(Classy_input)
+    DEPENDENCY(classy_input_params,Classy_input)
     #undef FUNCTION
   #undef CAPABILITY
 

--- a/yaml_files/CosmoBit_quickStart.yaml
+++ b/yaml_files/CosmoBit_quickStart.yaml
@@ -87,9 +87,9 @@ Parameters:
     ln10A_s: 3.044
     n_s: 0.9649
 
-  #AnnihilatingDM_photon:
-  #  mass: 0.001
-  #  sigmav: 0.000001
+  AnnihilatingDM_photon:
+    mass: 0.001
+    sigmav: 0.000001
 
   # Uncomment to allow for non-standard values of dNeff
   #dNurCMB:


### PR DESCRIPTION

`BE_INI_DEPENDENCY` of exo classy versions now `classy_parameters_EnergieInjection`. In this capability, all energy injection (EI) related parameters are added to the `Classy_input` instance obtained through a dependency on `classy_input_parameters`.

The problem we had before: if vanilla CLASS (i.e. no exoCLASS version) was installed and an annihilating/decaying DM model was scanned, CLASS ran and then failed because the EI related input parameters were not read. 

With these changes, the problematic scenario now fails during dependency resolution with the error that the annihilating/decaying DM model  (e.g. `AnnihilatingDM_photon`) is not in use. 


I think one part of the problem is that we can't/shouldn't remove the CLASS call from the classy BE_INI function. If we do that, we have to be super careful in every CLASS -output-dependent capability that everytime we try to get some result from the classy python object, the `cosmo.compute()` step has already been executed. And secondly, that we don't execute the `.compute` step twice. Otherwise we'd get segfaults or waste a whole lot of computing time. 

Tagging @pstoecker @tegonzalo and @patscott  in case you have an ideas. Thanks for your help! 
