### PR TITLE
Fix slow-down in typeComp (by-pass renaming for BOSSed types if not needed)

### DIFF
--- a/Core/src/depresolver.cpp
+++ b/Core/src/depresolver.cpp
@@ -275,10 +275,13 @@ namespace Gambit
     {
       bool match1, match2;
       // Loop over all the default versions of BOSSed backends and replace any corresponding *_default leading namespace with the explicit version.
-      for (auto it = Backends::backendInfo().default_safe_versions.begin(); it != Backends::backendInfo().default_safe_versions.end(); ++it)
+      if ((s1.find("_default") != std::string::npos) || (s2.find("_default") != std::string::npos))
       {
-        s1 = Utils::replace_leading_namespace(s1, it->first+"_default", it->first+"_"+it->second);
-        s2 = Utils::replace_leading_namespace(s2, it->first+"_default", it->first+"_"+it->second);
+        for (auto it = Backends::backendInfo().default_safe_versions.begin(); it != Backends::backendInfo().default_safe_versions.end(); ++it)
+        {
+          s1 = Utils::replace_leading_namespace(s1, it->first+"_default", it->first+"_"+it->second);
+          s2 = Utils::replace_leading_namespace(s2, it->first+"_default", it->first+"_"+it->second);
+        }
       }
       // Does it just match?
       if (stringComp(s1, s2, with_regex)) return true;


### PR DESCRIPTION
This PR fixes the speed issue that is mentioned in #202.

The code of `typeComp` (defined in `Core/src/depresolver.cpp`) is slowed down by a rather expensive call to `Utils::replace_leading_namespace` in which the dummy namespace with substring `"_default"` gets replaced by the actual namespace of the default version. This check is done for every possible input i.e. even for cases in which neither of the strings `s1` and `s2` (containing the names of datatypes known to GAMBIT) contains the substring "_default".

The fix in this PR adds an additional check before the code tries to resolve the BOSS-backend namespaces. If "_default" is not in either of the types to compare (`s1` and `s2`), this check and the call to `Utils::replace_leading_namespace` is skipped.

As I can only nominate one reviewer, I chose @andrewfowlie, but others that were involved in the discussion of #202 are welcomed to comment (@patscott , @bjfar )
