### PR TITLE
Prevent using C++17 if gnu version 7.2 is loaded.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,10 +271,10 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${mylibdir} )
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${mylibdir} )
 # Second, for multi-config builds (e.g. msvc)
 foreach(OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES} )
-    string(TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG )
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${mybindir} )
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${mylibdir} )
-    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${mylibdir} )
+  string(TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG )
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${mybindir} )
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${mylibdir} )
+  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${mylibdir} )
 endforeach()
 
 # Check if we are using 2019 intel compilers or gcc 6.1 or 6.2 together with pybind11, and forbid the use of C++17 if so.
@@ -289,9 +289,8 @@ endif()
 
 # Check if we are using gnu version 7.2, and forbid the use of C++17 if so.
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.1 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.3)
-    set(PERMIT_CXX17_CHECK FALSE)
+  set(PERMIT_CXX17_CHECK FALSE)
 endif()
-
 
 # Check for C++11, C++14 and C++17 support.
 include(CheckCXXCompilerFlag)


### PR DESCRIPTION
This is to fix an issue building with C++17 whilst using gnu version 7.2. Further details on bug can be found at:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83226

