### PR TITLE
Fix non-ASCII scratch dirs on crash

### DIFF
--- a/Elements/src/terminator.cpp
+++ b/Elements/src/terminator.cpp
@@ -7,7 +7,7 @@
 ///  *********************************************
 ///
 ///  Authors (add name and date if you modify):
-///   
+///
 ///  \author Pat Scott
 ///  \date 2014 Apr
 //
@@ -21,8 +21,8 @@
 void Gambit::terminator()
 {
   std::cout << std::endl << "Gambit has encountered an uncaught error during initialisation." << std::endl;
-  std::cout << std::endl << "Check the output logs for details." << std::endl;
-  std::cout << std::endl << "(Check your yaml file if you can't recall where the logs are.)" << std::endl << std::endl;
+  std::cout << std::endl << "Check the output logs for details.";
+  std::cout << std::endl << "(Unless you see an uninitialised logger message above, these will be in the location specified in your yaml file.)" << std::endl << std::endl;
 
   std::exception_ptr eptr = std::current_exception();
   try

--- a/Logs/include/gambit/Logs/logmaster.hpp
+++ b/Logs/include/gambit/Logs/logmaster.hpp
@@ -168,6 +168,9 @@ namespace Gambit
         /// Max number of threads that could potentially be running
         int globlMaxThreads;
 
+        /// Path to the default log file in the scratch dir
+        const std::string scratch_path;
+
         /// @{ Variables that need to be threadsafe
 
         /// int current_function; Can generalise to this if we discover that we really want to...

--- a/Logs/src/logmaster.cpp
+++ b/Logs/src/logmaster.cpp
@@ -60,6 +60,7 @@ namespace Gambit
       , MPIrank        (0)
       , MPIsize        (1)
       , globlMaxThreads(omp_get_max_threads())
+      , scratch_path   (Utils::runtime_scratch() + "default.log")
       , current_module (NULL)
       , current_backend(NULL)
       , stream         (NULL)
@@ -149,13 +150,12 @@ namespace Gambit
            // If LogMaster was never initialised, create a default log file to which the messages can be dumped.
            if (not loggers_readyQ)
            {
-             if (verbose) std::cout<<"Logger was never initialised! Creating default log messenger..."<<std::endl;
-             StdLogger* deflogger = new StdLogger(Utils::runtime_scratch() + "default.log");
+             if (verbose) std::cout<<std::endl<<"GAMBIT logger was never initialised. Outputting default log to "<<scratch_path<<std::endl;
+             StdLogger* deflogger = new StdLogger(scratch_path);
              std::set<int> deftag;
              deftag.insert(def);
              loggers[deftag] = deflogger;
              loggers_readyQ = true;
-             if (verbose) std::cout<<"Log messages will be delivered to '" << Utils::runtime_scratch() << "default.log'"<<std::endl;
            }
            // Dump buffered messages
            empty_backlog();

--- a/Utils/src/util_functions.cpp
+++ b/Utils/src/util_functions.cpp
@@ -55,6 +55,7 @@ namespace Gambit
     const char* whitespaces[] = {" ", "\t", "\n", "\f", "\r"};
 
     /// Return the path to the run-specific scratch directory
+    /// Don't call this from a destructor, as the internal static str may have already been destroyed.
     const str& runtime_scratch()
     {
       #ifdef WITH_MPI


### PR DESCRIPTION
Store the scratch dir path when initialising a LogMaster object, rather than trying to retrieve it by calling runtime_scratch() during destruction (this fails as the static variable in runtime_scratch seems to be destroyed before the LogMaster is).
