### PR TITLE
Compress standalone tarballs and include yaml_files.

### DIFF
--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -565,7 +565,6 @@ function(add_standalone_tarballs modules version)
                              COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/cmake ${dirname}/cmake
                              COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/config ${dirname}/config
                              COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/contrib ${dirname}/contrib
-                             COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/yaml_files ${dirname}/yaml_files
                              COMMAND ${CMAKE_COMMAND} -E remove -f 3Bit-${version}.tar.gz
                              COMMAND ${CMAKE_COMMAND} -E tar cz 3Bit-${version}.tar.gz ${dirname})
   add_dependencies(3Bit-${version}.tar.gz nuke-all)


### PR DESCRIPTION
Add yaml_files to the standalone tarballs and compress tarballs with gzip. Resolves #57 .

I was reading through the tickets and thought this is a quick fix, so I make an attempt on it. Is this what you had in mind @patscott ?

With this also comes a question: What is the use case for the standalone tarballs?