### PR TITLE
Add location of gsl-config to flexiblesusy sectiom in contrib.cmake. …

### DIFF
--- a/cmake/contrib.cmake
+++ b/cmake/contrib.cmake
@@ -310,6 +310,7 @@ if(";${GAMBIT_BITS};" MATCHES ";SpecBit;")
        --enable-shared-libs
        --with-shared-lib-ext=.so
        --with-shared-lib-cmd=${FS_SO_LINK_COMMAND}
+       --with-gsl-config=${GSL_CONFIG_EXECUTABLE}
       #--enable-verbose flag causes verbose output at runtime as well. Maybe set it dynamically somehow in future.
      )
 


### PR DESCRIPTION
…Not adding this caused gambit compilation to fail on the glasgow cluster (CentOS), as it was automatically detecting a gsl-config other than the one associated with the gsl that the rest of gambit was using. Discussed this morning in the GAMBIT-Contur/Rivet integration meeting.
@agbuckley @anderkve 