### PR TITLE
Update to classy build to enable compilation with intel.

### DIFF
--- a/cmake/backends.cmake
+++ b/cmake/backends.cmake
@@ -167,12 +167,12 @@ set(dir "${PROJECT_SOURCE_DIR}/Backends/installed/${name}/${ver}")
 check_ditch_status(${name} ${ver} ${dir})
 if(NOT ditched_${name}_${ver})
   ExternalProject_Add(${name}_${ver}
-    DOWNLOAD_COMMAND ${DL_BACKEND} ${dl} ${md5} ${dir} ${name} ${ver}
-    SOURCE_DIR ${dir}
-    BUILD_IN_SOURCE 1
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ${MAKE_PARALLEL} ${lib}.so FC=${CMAKE_Fortran_COMPILER} FOPT=${BACKEND_Fortran_FLAGS} MODULE=${FMODULE}
-    INSTALL_COMMAND ""
+  DOWNLOAD_COMMAND ${DL_BACKEND} ${dl} ${md5} ${dir} ${name} ${ver}
+  SOURCE_DIR ${dir}
+  BUILD_IN_SOURCE 1
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ${MAKE_PARALLEL} ${lib}.so FC=${CMAKE_Fortran_COMPILER} FOPT=${BACKEND_Fortran_FLAGS} MODULE=${FMODULE}
+  INSTALL_COMMAND ""
   )
   add_extra_targets("backend" ${name} ${ver} ${dir} ${dl} clean)
   set_as_default_version("backend" ${name} ${ver})


### PR DESCRIPTION
This is a draft to enable classy to be compiled with intel (tested on the cambridge system).

1. is there a reason this would not be recommended?
2. How can I make the gnu `-lgomp` to intel `liomp5` substitution conditional on intel compilation? At the moment I can't see how to do this within the `ExternalProject_Add` command, and wanted to check if there were a cleverer way to do it then just copy-pasting the entire `ExternalProject_Add` command into an `if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel")` statement.
3. Should I update the older classy versions with this modification too?