### PR TITLE
Fixed module diagnostics

### DIFF
--- a/Core/src/core.cpp
+++ b/Core/src/core.cpp
@@ -203,6 +203,7 @@ namespace Gambit
   /// Add a new module to modules list
   void gambit_core::registerModule(str module, str ref)
   {
+    modules.insert(module);
     if(ref == "REFERENCE")
       module_citation_keys[module] = "";
     else

--- a/Utils/scripts/find_all_gambit_bits.py
+++ b/Utils/scripts/find_all_gambit_bits.py
@@ -15,9 +15,9 @@ def get_bits_from_directory_list(gambit_directory):
         gambit_directory (str): Directory to search in. To work properly this has to be the Gambit source directory.
 
     Returns:
-        list: sorted list of Gambit Bits
+        list: sorted list of Gambit Bits, except ScannerBit
     """
-    return sorted(set([directory for directory in os.listdir(gambit_directory) if "Bit" in directory]))
+    return sorted(set([directory for directory in os.listdir(gambit_directory) if "Bit" in directory and "ScannerBit" not in directory and os.path.isdir(directory)]))
 
 
 def write_list_to_yaml(list_of_bits, output_file, yaml_key="gambit_bits"):


### PR DESCRIPTION
Fixes #318 

This PR just fixes the problem with ditched modules. This was just a bug that I introduced a while ago.
In addition, I removed `ScannerBit` from the list of harvested modules (it's not really a bit, i.e., ditchable), and also made sure that harvesting of bits only picks out the directories, not other stuff with `Bit` in the name (e.g. standalone executables)

Should be fairly easy to review. @patscott do you have time to do it?