### PR TITLE
Issue 281

### DIFF
--- a/Core/src/depresolver.cpp
+++ b/Core/src/depresolver.cpp
@@ -2426,7 +2426,7 @@ namespace Gambit
     }
 
     /// Construct metadata information from used observables, rules and options
-    /// Note: No keys are can be identical (or differing just by capitalisation) 
+    /// Note: No keys can be identical (or differing only by capitalisation) 
     ///       to those printed in the main file, otherwise the sqlite printer fails
     map_str_str DependencyResolver::getMetadata()
     {
@@ -2438,17 +2438,17 @@ namespace Gambit
       // Date
       auto now = std::chrono::system_clock::now();
       auto in_time_t = std::chrono::system_clock::to_time_t(now);
-      
+
       std::stringstream ss;
       ss << std::put_time(std::localtime(&in_time_t), "%Y-%m-%d %H:%M");
       metadata["Date"] =  ss.str();
-      
+
       // scanID
       if (boundIniFile->getValueOrDef<bool>(true, "print_scanID"))
       {
         ss.str("");
         ss << scanID;
-        metadata["Scan ID"] = ss.str();
+        metadata["Scan_ID"] = ss.str();
       }
 
       // Parameters
@@ -2586,22 +2586,22 @@ namespace Gambit
     void DependencyResolver::set_scanID()
     {
       // Get the scanID from the yaml node.
-      int code = boundIniFile->getValueOrDef<int>(-1, "scanID");
+      scanID = boundIniFile->getValueOrDef<int>(-1, "scanID");
     
-      // If code is supplied by user, use that
-      if (code != -1)
+      // If scanID is supplied by user, use that
+      if (scanID != -1)
       {
-        scanID = code;
-      } else {
-        int timenow;
-        auto now = std::chrono::system_clock::now();
-        auto in_time_t = std::chrono::system_clock::to_time_t(now);
-        auto ms = std::chrono::duration_cast<std::chrono::milliseconds> (now.time_since_epoch()) - std::chrono::duration_cast<std::chrono::seconds> (now.time_since_epoch());
+        return;
+      }
+      else
+      {
+        const std::chrono::time_point<std::chrono::system_clock> now = std::chrono::system_clock::now();
+        std::time_t in_time_t = std::chrono::system_clock::to_time_t(now);
+        std::chrono::milliseconds ms = std::chrono::duration_cast<std::chrono::milliseconds> (now.time_since_epoch()) - std::chrono::duration_cast<std::chrono::seconds> (now.time_since_epoch());
         std::stringstream ss;
         ss << std::put_time(std::localtime(&in_time_t), "%H%M%S");
         ss << ms.count();
-        ss >> timenow;
-        scanID = timenow;
+        ss >> scanID;
       }
     }
 

--- a/Printers/include/gambit/Printers/basebaseprinter.hpp
+++ b/Printers/include/gambit/Printers/basebaseprinter.hpp
@@ -115,7 +115,7 @@ namespace Gambit
 
         bool get_resume() { return resume; }
         void set_resume(bool rflag) { resume = rflag; }
-        
+
         /// Signal printer that scan is finished, and final output needs to be performed
         virtual void finalise(bool abnormal=false) = 0;
 

--- a/Printers/include/gambit/Printers/printers/hdf5printer_v2.hpp
+++ b/Printers/include/gambit/Printers/printers/hdf5printer_v2.hpp
@@ -1363,7 +1363,7 @@ namespace Gambit
 
         /// Search the existing output and find the highest used pointIDs for each rank
         std::map<ulong, ulong> get_highest_PPIDs(const int mpisize);
-        
+
         /// Open (and lock) output HDF5 file and obtain HDF5 handles
         void lock_and_open_file(const char access_type='w'); // read/write allowed by default
 
@@ -1514,7 +1514,7 @@ namespace Gambit
 
         /// Report length of buffer for HDF5 output
         std::size_t get_buffer_length();
-        
+
         /// Base class virtual function overloads
         /// (the public virtual interface)
         ///@{
@@ -1611,7 +1611,7 @@ namespace Gambit
 
         /// Search the existing output and find the highest used pointIDs for each rank
         std::map<ulong, ulong> get_highest_PPIDs_from_HDF5();
-        
+
         /// Check all datasets in a group for length inconsistencies
         /// and correct them if possible
         void check_consistency(bool attempt_repair);

--- a/Printers/src/printers/hdf5printer_v2/hdf5printer_v2.cpp
+++ b/Printers/src/printers/hdf5printer_v2/hdf5printer_v2.cpp
@@ -1587,7 +1587,6 @@ namespace Gambit
 
                         logger() << LogTags::info << "Extracted highest pointID calculated on rank "<<myRank<<" process during previous scan (it was "<< highests <<") from combined output. Operation took "<<std::chrono::duration_cast<std::chrono::seconds>(time_taken).count()<<" seconds." << EOM;
 
-
                     }
                     else
                     {

--- a/yaml_files/spartan.yaml
+++ b/yaml_files/spartan.yaml
@@ -139,12 +139,13 @@ Logger:
 KeyValues:
 
   default_output_path: "${PWD}/runs/spartan"
-  
+
   # An additional entry in the dataset and metadata, useful for identifying which
   # points correspond to a given scan in combined datasets.
   # The default is for print_scanID: true, 
   # and for it to print the date and time as an int of the form
-  # scanID: HourMinuteSecondMillisecond. This can be overwritten to any int. 
+  # scanID: HourMinuteSecondMillisecond. This can be overwritten to any integer.
+  print_scanID: true
   scanID: 1
 
   rng:


### PR DESCRIPTION
This addresses Issue 281, in which an extra entry to the data file is written, containing a scan ID. This way you could use this to identify which parameter points come from which scan if you've combined multiple scan results together (or resumed scans).
It also adds this scanID into the new YAML metadata that Tomas recently added, so the user can tell which metadata corresponds to which points.
By default, it will set this scanID to be of the form: MonthDayHourMinute (e.g. 1:22pm Aug 30 would be 8301322). But the user can also specify what code they want to use in the keyvalues section of the YAML instead (example usage in spartan.yaml).

Lastly while doing this, I noticed that for the sqlite printer you cannot have any entry in the metadata that is the same (or only differs by capitalisation) as in your main output. This works for any of the other printers. I'm not sure if this is something we want to create an issue for since it is easy to simply rename your metadata entry (e.g. I just added a space between scan and ID). I just added a comment in the getMetadata() function, so anyone adding to this function is aware.