### PR TITLE
Added info message about building CBS in Release mode

### DIFF
--- a/cmake/standalones.cmake
+++ b/cmake/standalones.cmake
@@ -31,3 +31,12 @@ add_standalone(DarkBit_standalone_ScalarSingletDM_Z2 SOURCES DarkBit/examples/Da
 add_standalone(DarkBit_standalone_WIMP SOURCES DarkBit/examples/DarkBit_standalone_WIMP.cpp MODULES DarkBit)
 add_standalone(3bithit SOURCES DecayBit/examples/3bithit.cpp MODULES DecayBit SpecBit PrecisionBit)
 add_standalone(FlavBit_standalone SOURCES FlavBit/examples/FlavBit_standalone_example.cpp MODULES FlavBit)
+
+# Add a message that is only shown if CBS is built 
+# and -O3 level compiler optimisations are not activated.
+if((NOT ${CMAKE_BUILD_TYPE} STREQUAL "Release") AND (NOT ${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo"))
+  add_custom_command(
+    TARGET CBS POST_BUILD
+    COMMENT "\n${BoldYellow}-- You have built CBS with CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}. For best performance we recommend building CBS in 'Release' mode. You can do this by rerunning cmake with the option -DCMAKE_BUILD_TYPE=Release and then rebuild CBS. ${ColourReset}\n\n"
+  )
+endif()


### PR DESCRIPTION
Added info message that is printed if CBS is built but CMAKE_BUILD_TYPE is not set to Release.

@ChrisJChang, here's the cmake message I suggested in the CBS emails. Could you just run a quick `cmake -DCMAKE_BUILD_TYPE=None` and  `make CBS` to confirm that this works as expected? You should get a message at the very end of the CBS build.