### PR TITLE
Small fix to the Options::toMap() method, to tackle empty YAML nodes.

### DIFF
--- a/Utils/include/gambit/Utils/yaml_options.hpp
+++ b/Utils/include/gambit/Utils/yaml_options.hpp
@@ -292,7 +292,9 @@ namespace Gambit
               key += node.first[j].as<str>() + ",";
             key += node.first[node.first.size()-1].as<str>() + "]";
           }
-          if(node.second.IsScalar())
+          if(node.second.IsNull())
+            map[head + key] = "";
+          else if(node.second.IsScalar())
             map[head + key] = node.second.as<str>();
           else if(node.second.IsMap())
             Options(node.second).toMap(map, head + key);


### PR DESCRIPTION
The `Options::toMap` method needs to tackle empty YAML nodes. Currently it produces an error `Couldn't convert options to map. YAML type unknown.` for e.g. the following correct  YAML configuration for using ScannerBit's multidimensional priors, due to the empty `mu` and `sigma` nodes:

``` yaml
Parameters:
  NormalDist:
    mu:
    sigma:

Priors:
  my_prior:
    parameters: ["NormalDist::mu", "NormalDist::sigma"]
    prior_type: gaussian
    mu: [18, 5]
    sigma: [3.0, 1]
```

PS: @gregorydavidmartinez, this means that you can undo your temp fix on the `python_scanners` branch. Once this PR is merged into `master` we can pull it into `python_scanners` from there.