### PR TITLE
Tie inclusion of HepMC/YODA to ColliderBit

### DIFF
--- a/cmake/contrib.cmake
+++ b/cmake/contrib.cmake
@@ -171,7 +171,7 @@ include_directories("${LHEF_INCLUDE_DIR}")
 
 #contrib/HepMC3; include only if ColliderBit is in use.
 if(";${GAMBIT_BITS};" MATCHES ";ColliderBit;")
-  message("ColliderBit included, so HepMC is included too")
+  message("   ColliderBit included, so HepMC is included too")
   set(WITH_HEPMC ON)
 else()
   set(WITH_HEPMC OFF)
@@ -235,7 +235,7 @@ endif()
 
 #contrib/YODA; include if ColliderBit is in, don't otherwise
 if(";${GAMBIT_BITS};" MATCHES ";ColliderBit;")
-  message("ColliderBit included, so YODA is included too")
+  message("   ColliderBit included, so YODA is included too")
   set(WITH_YODA ON)
 else()
   set(WITH_YODA OFF)


### PR DESCRIPTION
As discussed earlier at f2f, ColliderBit needs YODA & HepMC, and you'll never need YODA/HepMC without ColliderBit. So this ties WITH_YODA, WITH_HEPMC to whether or not ColliderBit is included.
Closes #425 