### PR TITLE
Fix warning and error for interpolation routines

### DIFF
--- a/ColliderBit/src/ColliderBit_InterpolatedYields.cpp
+++ b/ColliderBit/src/ColliderBit_InterpolatedYields.cpp
@@ -1886,8 +1886,9 @@ namespace Gambit
         first = false;
       }
 
-      double mMed;
-      double gq;
+      // Initialise to squash warning, these values will always be overwritten
+      double mMed = 0.0;
+      double gq = 0.0;
 
       // Pull Decay widths from CalcHEP
       DecayTable::Entry decays;
@@ -1920,6 +1921,10 @@ namespace Gambit
         mMed = spec.get(Par::Pole_Mass, "Y1");
         gq   = spec.get(Par::dimensionless, "gVq");
         decays = *Dep::Y1_decay_rates;
+      }
+      else
+      {
+        ColliderBit_error().raise(LOCAL_INFO, "ERROR! ColliderBit_InterpolatedYields: Cannot use DMsimp Dijet likelihood for this model.");
       }
 
       double total_width = decays.width_in_GeV;

--- a/Utils/src/interp_collection.cpp
+++ b/Utils/src/interp_collection.cpp
@@ -249,8 +249,8 @@ namespace Gambit
       for (size_t k=0;k<fi_values.size();k++)
       {
         // Reset Values
-        test_u[0] = false; test_u[1] = false;
-        test_l[0] = false; test_l[1] = false;
+        test_u[0] = false;
+        test_l[0] = false;
 
         // Check whether the values correspond to any of the upper/lower values. skip calculation if not...
         if (x1_vec_unsorted[k]==xi_upper[0]) { test_u[0]=true;}


### PR DESCRIPTION
This fixes a copy-paste bug in the 1D interpolation routine, and removes a warning for an uninitialised variables.