### PR TITLE
delete superfluous semi-colons

### DIFF
--- a/Backends/include/gambit/Backends/frontends/SPheno_4_0_3.hpp
+++ b/Backends/include/gambit/Backends/frontends/SPheno_4_0_3.hpp
@@ -119,8 +119,8 @@ BE_VARIABLE(UseNewBoundaryEW, Flogical, ("__control_MOD_usenewboundaryew", "cont
 BE_VARIABLE(UseNewScale, Flogical, ("__control_MOD_usenewscale", "control_mp_usenewscale"), "SPheno_internal")
 BE_VARIABLE(WriteOut, Flogical, ("__control_MOD_writeout", "control_mp_writeout_"), "SPheno_internal")
 BE_VARIABLE(Switch_to_1_loop_mh, Flogical, ("__control_MOD_switch_to_1_loop_mh", "control_mp_switch_to_1_loop_mh_"), "SPheno_internal")
-BE_VARIABLE(l_fit_RP_parameters, Flogical, ("__control_MOD_l_fit_rp_parameters", "control_mp_l_fit_rp_parameters_"), "SPheno_internal");
-BE_VARIABLE(l_CSrp, Flogical, ("__control_MOD_l_csrp", "control_mp_l_csrp_"), "SPheno_internal");
+BE_VARIABLE(l_fit_RP_parameters, Flogical, ("__control_MOD_l_fit_rp_parameters", "control_mp_l_fit_rp_parameters_"), "SPheno_internal")
+BE_VARIABLE(l_CSrp, Flogical, ("__control_MOD_l_csrp", "control_mp_l_csrp_"), "SPheno_internal")
 BE_VARIABLE(ErrorHandler_cptr, fptr_void, ("__control_MOD_errorhandler_cptr", "control_mp_errorhandler_cptr_"), "SPheno_internal")
 
 

--- a/Elements/include/gambit/Elements/daFunk.hpp
+++ b/Elements/include/gambit/Elements/daFunk.hpp
@@ -928,7 +928,7 @@ namespace daFunk
     {
         singularities[arg].push_back(std::pair<Funk, Funk>(pos, width));
         return shared_from_this();
-    };
+    }
     inline Funk FunkBase::set_singularity(std::string arg, double pos, Funk width)
     { return shared_from_this()->set_singularity(arg, cnst(pos), width); }
     inline Funk FunkBase::set_singularity(std::string arg, double pos, double width)
@@ -1464,7 +1464,7 @@ namespace daFunk
     };
     //inline Funk print(std::string msg) { return Funk(new Bottle(msg)); }
     inline Funk FunkBase::print(std::string msg)
-    { return Funk(new Bottle(shared_from_this(), msg)); };
+    { return Funk(new Bottle(shared_from_this(), msg)); }
 
 
     //

--- a/ScannerBit/include/gambit/ScannerBit/scanner_utils.hpp
+++ b/ScannerBit/include/gambit/ScannerBit/scanner_utils.hpp
@@ -297,7 +297,7 @@ namespace Gambit
         typename std::enable_if<std::is_floating_point<ret>::value, ret>::type scanner_plugin_def_ret()
         {
             return -std::pow(10.0, std::numeric_limits<double>::max_exponent10);
-        };
+        }
         /// @}
 
         /********************************/
@@ -310,37 +310,37 @@ namespace Gambit
         inline double pow(const double &a)
         {
             return a*pow<i-1>(a);
-        };
+        }
 
         template <>
         inline double pow<0>(const double &)
         {
             return 1.0;
-        };
+        }
 
         template <>
         inline double pow<1>(const double &a)
         {
             return a;
-        };
+        }
 
         template <int i>
         inline int pow(const int &a)
         {
             return a*pow<i-1>(a);
-        };
+        }
 
         template <>
         inline int pow<0>(const int &)
         {
             return 1;
-        };
+        }
 
         template <>
         inline int pow<1>(const int &a)
         {
             return a;
-        };
+        }
         /// @}
 
         /********************************/
@@ -643,7 +643,7 @@ namespace Gambit
         {
             out.write(reinterpret_cast<char *>(&param), sizeof(T));
             //out << param << std::endl;
-        };
+        }
 
         template <typename T>
         inline typename std::enable_if <is_container<T>::value, void>::type
@@ -669,7 +669,7 @@ namespace Gambit
         {
             in.read((char *)&param, sizeof(T));
             //in >> param;
-        };
+        }
 
         template <typename T>
         inline typename std::enable_if <is_container<T>::value, void>::type
@@ -694,7 +694,7 @@ namespace Gambit
         resume_size_of(T &)
         {
             return sizeof(T);
-        };
+        }
 
         template <typename T>
         inline typename std::enable_if <is_container<T>::value, size_t>::type


### PR DESCRIPTION
I don't know why these didn't show up on previous tests but i think they give me errors with g++-9.4.0 and I think cleaning them up is good anyway.