### PR TITLE
Remove two semicolons.

### DIFF
--- a/ScannerBit/include/gambit/ScannerBit/py_module_scanbit.hpp
+++ b/ScannerBit/include/gambit/ScannerBit/py_module_scanbit.hpp
@@ -155,8 +155,8 @@ __SCAN_PLUGIN_GET_INIFILE_VALUE__(self.get_inifile_value)                       
 typedef std::unordered_map<std::string, double> map_doub_type_;
 typedef std::vector<std::string> vec_str_type_;
 
-PYBIND11_MAKE_OPAQUE(map_doub_type_);
-PYBIND11_MAKE_OPAQUE(vec_str_type_);
+PYBIND11_MAKE_OPAQUE(map_doub_type_)
+PYBIND11_MAKE_OPAQUE(vec_str_type_)
 
 /**
  * @brief A pybind11 module named "scannerbit".


### PR DESCRIPTION
This was a small change that was necessary for GAMBIT to compile on my machine for the python_scanners work. Anders removed them in the python_scanners PR, but they appear to have been re-added in a commit named "Added copilot's comments and reorganized. " by @gregorydavidmartinez .

Assigning @anderkve as a reviewer, since he already addressed this previously.