### PR TITLE
Remove incorrect use of const in Event.h

### DIFF
--- a/contrib/heputils/include/HEPUtils/Event.h
+++ b/contrib/heputils/include/HEPUtils/Event.h
@@ -43,7 +43,7 @@ namespace HEPUtils {
     using CSeqBasePtr = std::shared_ptr<const FJNS::ClusterSequence>;
     
     /// Hold the cluster sequences corresponding to jets, to keep them alive
-    std::map<const std::string, CSeqBasePtr> _cseqs;
+    std::map<std::string, CSeqBasePtr> _cseqs;
     
     /// Missing momentum vector
     P4 _pmiss;


### PR DESCRIPTION
I accidentally introduced this in my recent heputils bug fixes. This was causing the Mac CIs to fail because they were getting confused about an overload.

@agbuckley , this will require updating on the main heputils repo as well. Happy to make another PR if you would like.