### PR TITLE
Pythia events for THDM model.

### DIFF
--- a/Backends/patches/pythia/8.212/patch_pythia_8.212.dif
+++ b/Backends/patches/pythia/8.212/patch_pythia_8.212.dif
@@ -6656,3 +6656,191 @@ diff -rupN pythia_8.212_original/src/SigmaProcess.cc pythia_8.212_patched/src/Si
      p2ME3 *= compFac;
      p2ME4 *= compFac;
      p2ME5 *= compFac;
+diff -rupN pythia_8.212_original/src/SusyCouplings.cc pythia_8.212_patched/src/SusyCouplings.cc
+--- pythia_8.212_original/src/SusyCouplings.cc	2019-05-15 19:17:51.000000000 +1000
++++ pythia_8.212_patched/src/SusyCouplings.cc	2023-09-21 15:23:52.881787043 +1000
+@@ -154,48 +154,142 @@
+   double cosa = cos(alphaHiggs);
+   double sina = sin(alphaHiggs);
+ 
+-  // h0
+-  settingsPtr->parm("HiggsH1:coup2d", -sina/cosb);
+-  settingsPtr->parm("HiggsH1:coup2u",  cosa/sinb);
+-  settingsPtr->parm("HiggsH1:coup2l", cosa/sinb);
+-  settingsPtr->parm("HiggsH1:coup2Z", sba);
+-  settingsPtr->parm("HiggsH1:coup2W", sba);
+-  // H0
+-  settingsPtr->parm("HiggsH2:coup2d", cosa/cosb);
+-  settingsPtr->parm("HiggsH2:coup2u", sina/sinb);
+-  settingsPtr->parm("HiggsH2:coup2l", sina/sinb);
+-  settingsPtr->parm("HiggsH2:coup2Z", cba);
+-  settingsPtr->parm("HiggsH2:coup2W", cba);
+-  settingsPtr->parm("HiggsH2:coup2H1Z", 0.0);
+-  settingsPtr->parm("HiggsH2:coup2HchgW", sba);
+-  // A0
+-  settingsPtr->parm("HiggsA3:coup2d", tanb);
+-  settingsPtr->parm("HiggsA3:coup2u", cosb/sinb);
+-  settingsPtr->parm("HiggsA3:coup2l", cosb/sinb);
+-  settingsPtr->parm("HiggsA3:coup2Z", 0.0);
+-  settingsPtr->parm("HiggsA3:coup2W", 0.0);
+-  settingsPtr->parm("HiggsA3:coup2H1Z", cba);
+-  settingsPtr->parm("HiggsA3:coup2H2Z", sba);
+-  settingsPtr->parm("HiggsA3:coup2HchgW", 1.0);
+-
+-  // H^+
+-  settingsPtr->parm("HiggsHchg:tanBeta", tanb);
+-  settingsPtr->parm("HiggsHchg:coup2H1W", cba);
+-  settingsPtr->parm("HiggsHchg:coup2H2W", sba);
+-
+-  // Triple higgs couplings
+-
+-  double cbpa = cos(beta+alphaHiggs);
+-  double sbpa = sin(beta+alphaHiggs);
+-
+-  settingsPtr->parm("HiggsH1:coup2Hchg", cos(2*beta)*sbpa + 2*pow2(cosW)*sba);
+-  settingsPtr->parm("HiggsH2:coup2Hchg", -cos(2*beta)*cbpa + 2*pow2(cosW)*cba);
+-  settingsPtr->parm("HiggsH2:coup2H1H1", 2*sin(2*alphaHiggs)*sbpa
+-    - cos(2*alphaHiggs)*cbpa);
+-  settingsPtr->parm("HiggsH2:coup2A3A3", -cos(2*beta)*cbpa);
+-  settingsPtr->parm("HiggsH2:coup2A3H1", 0.0);
+-  settingsPtr->parm("HiggsA3:coup2H1H1", 0.0);
+-  settingsPtr->parm("HiggsA3:coup2Hchg", 0.0);
++  // GAMBIT HACK: If the THDMCOUPLINGS block is present (if the first value is present), pull in the couplings from the SLHA rather than calculating internally in Pythia
++  //              Check for the first entry as a proof that the block exists
++  double par1;
++
++  if (slhaPtr->getEntry("THDMCOUPLINGS", 1, par1))
++  {
++    double par2,par3,par4,par5,par6,par7,par8,par9,par10;
++    double par11,par12,par13,par14,par15,par16,par17,par18,par19,par20;
++    double par21,par22,par23,par24,par25,par26,par27,par28,par29,par30;
++    // Loop over each parameter and pull it from the block
++    std::vector<bool> worked;
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 1, par1));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 2, par2));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 3, par3));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 4, par4));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 5, par5));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 6, par6));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 7, par7));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 8, par8));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 9, par9));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 10, par10));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 11, par11));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 12, par12));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 13, par13));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 14, par14));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 15, par15));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 16, par16));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 17, par17));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 18, par18));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 19, par19));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 20, par20));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 21, par21));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 22, par22));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 23, par23));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 24, par24));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 25, par25));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 26, par26));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 27, par27));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 28, par28));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 29, par29));
++    worked.push_back(slhaPtr->getEntry("THDMCOUPLINGS", 30, par30));
++    
++    // Check whether any were missing in the block
++    for (size_t i = 0 ; i < worked.size(); i++)
++    {
++      if (worked[i] == false)
++      {
++        infoPtr->errorMsg("ERROR in PYTHIA: Missing THDMCouplings in SLHAea.");
++      }
++    }
++    
++    
++    // Assign parameters
++    // h0
++    settingsPtr->parm("HiggsH1:coup2d", par1);
++    settingsPtr->parm("HiggsH1:coup2u", par2);
++    settingsPtr->parm("HiggsH1:coup2l", par3);
++    settingsPtr->parm("HiggsH1:coup2Z", par4);
++    settingsPtr->parm("HiggsH1:coup2W", par5);
++    // H0
++    settingsPtr->parm("HiggsH2:coup2d", par6);
++    settingsPtr->parm("HiggsH2:coup2u", par7);
++    settingsPtr->parm("HiggsH2:coup2l", par8);
++    settingsPtr->parm("HiggsH2:coup2Z", par9);
++    settingsPtr->parm("HiggsH2:coup2W", par10);
++    settingsPtr->parm("HiggsH2:coup2H1Z", par11);
++    settingsPtr->parm("HiggsH2:coup2HchgW", par12);
++    // A0
++    settingsPtr->parm("HiggsA3:coup2d", par13);
++    settingsPtr->parm("HiggsA3:coup2u", par14);
++    settingsPtr->parm("HiggsA3:coup2l", par15);
++    settingsPtr->parm("HiggsA3:coup2Z", par16);
++    settingsPtr->parm("HiggsA3:coup2W", par17);
++    settingsPtr->parm("HiggsA3:coup2H1Z", par18);
++    settingsPtr->parm("HiggsA3:coup2H2Z", par19);
++    settingsPtr->parm("HiggsA3:coup2HchgW", par20);
++
++    // H^+
++    settingsPtr->parm("HiggsHchg:tanBeta", par21);
++    settingsPtr->parm("HiggsHchg:coup2H1W", par22);
++    settingsPtr->parm("HiggsHchg:coup2H2W", par23);
++
++    // Triple higgs couplings
++    settingsPtr->parm("HiggsH1:coup2Hchg", par24);
++    settingsPtr->parm("HiggsH2:coup2Hchg", par25);
++    settingsPtr->parm("HiggsH2:coup2H1H1", par26);
++    settingsPtr->parm("HiggsH2:coup2A3A3", par27);
++    settingsPtr->parm("HiggsH2:coup2A3H1", par28);
++    settingsPtr->parm("HiggsA3:coup2H1H1", par29);
++    settingsPtr->parm("HiggsA3:coup2Hchg", par30);
++  }
++  else
++  {
++    // h0
++    settingsPtr->parm("HiggsH1:coup2d", -sina/cosb);
++    settingsPtr->parm("HiggsH1:coup2u",  cosa/sinb);
++    settingsPtr->parm("HiggsH1:coup2l", cosa/sinb);
++    settingsPtr->parm("HiggsH1:coup2Z", sba);
++    settingsPtr->parm("HiggsH1:coup2W", sba);
++    // H0
++    settingsPtr->parm("HiggsH2:coup2d", cosa/cosb);
++    settingsPtr->parm("HiggsH2:coup2u", sina/sinb);
++    settingsPtr->parm("HiggsH2:coup2l", sina/sinb);
++    settingsPtr->parm("HiggsH2:coup2Z", cba);
++    settingsPtr->parm("HiggsH2:coup2W", cba);
++    settingsPtr->parm("HiggsH2:coup2H1Z", 0.0);
++    settingsPtr->parm("HiggsH2:coup2HchgW", sba);
++    // A0
++    settingsPtr->parm("HiggsA3:coup2d", tanb);
++    settingsPtr->parm("HiggsA3:coup2u", cosb/sinb);
++    settingsPtr->parm("HiggsA3:coup2l", cosb/sinb);
++    settingsPtr->parm("HiggsA3:coup2Z", 0.0);
++    settingsPtr->parm("HiggsA3:coup2W", 0.0);
++    settingsPtr->parm("HiggsA3:coup2H1Z", cba);
++    settingsPtr->parm("HiggsA3:coup2H2Z", sba);
++    settingsPtr->parm("HiggsA3:coup2HchgW", 1.0);
++
++    // H^+
++    settingsPtr->parm("HiggsHchg:tanBeta", tanb);
++    settingsPtr->parm("HiggsHchg:coup2H1W", cba);
++    settingsPtr->parm("HiggsHchg:coup2H2W", sba);
++
++    // Triple higgs couplings
++
++    double cbpa = cos(beta+alphaHiggs);
++    double sbpa = sin(beta+alphaHiggs);
++
++    settingsPtr->parm("HiggsH1:coup2Hchg", cos(2*beta)*sbpa + 2*pow2(cosW)*sba);
++    settingsPtr->parm("HiggsH2:coup2Hchg", -cos(2*beta)*cbpa + 2*pow2(cosW)*cba);
++    settingsPtr->parm("HiggsH2:coup2H1H1", 2*sin(2*alphaHiggs)*sbpa
++      - cos(2*alphaHiggs)*cbpa);
++    settingsPtr->parm("HiggsH2:coup2A3A3", -cos(2*beta)*cbpa);
++    settingsPtr->parm("HiggsH2:coup2A3H1", 0.0);
++    settingsPtr->parm("HiggsA3:coup2H1H1", 0.0);
++    settingsPtr->parm("HiggsA3:coup2Hchg", 0.0);
++  }
+ 
+   // Shorthand for squark mixing matrices
+   LHmatrixBlock<6> Ru(slhaPtr->usqmix);

--- a/ColliderBit/include/gambit/ColliderBit/models/SUSY_extras.hpp
+++ b/ColliderBit/include/gambit/ColliderBit/models/SUSY_extras.hpp
@@ -151,8 +151,10 @@
     START_FUNCTION(SLHAstruct)
     ALLOW_MODELS(MSSM63atQ, MSSM63atQ_mG, MSSM63atQ_mA, MSSM63atQ_mA_mG, MSSM63atMGUT, MSSM63atMGUT_mG, MSSM63atMGUT_mA, MSSM63atMGUT_mA_mG)
     ALLOW_MODELS(ColliderBit_SLHA_file_model, ColliderBit_SLHA_scan_model)
+    ALLOW_MODELS(THDM, THDMatQ)
     MODEL_CONDITIONAL_DEPENDENCY(SLHAFileNameAndContent, pair_str_SLHAstruct, ColliderBit_SLHA_file_model, ColliderBit_SLHA_scan_model)
     MODEL_CONDITIONAL_DEPENDENCY(MSSM_spectrum, Spectrum, MSSM63atQ, MSSM63atMGUT, MSSM63atQ_mA, MSSM63atMGUT_mA)
+    MODEL_CONDITIONAL_DEPENDENCY(THDM_spectrum, Spectrum, THDM, THDMatQ)
     #undef FUNCTION
   #undef CAPABILITY
 
@@ -162,8 +164,10 @@
     START_FUNCTION(SLHAstruct)
     ALLOW_MODELS(MSSM63atQ, MSSM63atQ_mG, MSSM63atQ_mA, MSSM63atQ_mA_mG, MSSM63atMGUT, MSSM63atMGUT_mG, MSSM63atMGUT_mA, MSSM63atMGUT_mA_mG)
     ALLOW_MODELS(ColliderBit_SLHA_file_model, ColliderBit_SLHA_scan_model)
+    ALLOW_MODELS(THDM, THDMatQ)
     MODEL_CONDITIONAL_DEPENDENCY(SLHAFileNameAndContent, pair_str_SLHAstruct, ColliderBit_SLHA_file_model, ColliderBit_SLHA_scan_model)
     MODEL_CONDITIONAL_DEPENDENCY(MSSM_spectrum, Spectrum, MSSM63atQ, MSSM63atMGUT, MSSM63atQ_mA, MSSM63atMGUT_mA)
+    MODEL_CONDITIONAL_DEPENDENCY(THDM_spectrum, Spectrum, THDM, THDMatQ)
     #undef FUNCTION
   #undef CAPABILITY
   /// @}

--- a/ColliderBit/include/gambit/ColliderBit/models/THDM.hpp
+++ b/ColliderBit/include/gambit/ColliderBit/models/THDM.hpp
@@ -1,0 +1,95 @@
+//   GAMBIT: Global and Modular BSM Inference Tool
+//   *********************************************
+///  \file
+///
+///  Rollcall header for THDM models in
+///  ColliderBit.
+///
+///  *********************************************
+///
+///  Authors (add name and date if you modify):
+///
+///  \author Chris Chang
+///  \date 2023
+///
+///  *********************************************
+
+#pragma once
+
+#include "gambit/ColliderBit/models/SUSY_extras.hpp"
+
+#define MODULE ColliderBit
+
+
+  // Construct an SLHAea object with spectrum and decays for Pythia
+  #define CAPABILITY SpectrumAndDecaysForPythia
+
+    #define FUNCTION getSpectrumAndDecaysForPythia_THDM
+    START_FUNCTION(SLHAstruct)
+    DEPENDENCY(decay_rates, DecayTable)
+    DEPENDENCY(THDM_spectrum, Spectrum)
+    DEPENDENCY(Higgs_Couplings, HiggsCouplingsTable)
+    DEPENDENCY(couplingtable_THDM, CouplingTable)
+    ALLOW_MODELS(THDM, THDMatQ)
+    #undef FUNCTION
+
+  #undef CAPABILITY
+
+
+  // Get Monte Carlo event generator
+  #define CAPABILITY HardScatteringSim
+
+    #define FUNCTION getPythia_THDM
+    START_FUNCTION(Py8Collider_defaultversion)
+    NEEDS_MANAGER(RunMC, MCLoopInfo)
+    NEEDS_CLASSES_FROM(Pythia, default)
+    ALLOW_MODELS(THDM, THDMatQ)
+    DEPENDENCY(SpectrumAndDecaysForPythia, SLHAstruct)
+    #undef FUNCTION
+
+    #define FUNCTION getPythiaAsBase_THDM
+    START_FUNCTION(const BaseCollider*)
+    NEEDS_MANAGER(RunMC, MCLoopInfo)
+    NEEDS_CLASSES_FROM(Pythia, default)
+    DEPENDENCY(HardScatteringSim, Py8Collider_defaultversion)
+    ALLOW_MODELS(THDM, THDMatQ)
+    ALLOW_MODELS(ColliderBit_SLHA_file_model, ColliderBit_SLHA_scan_model)
+    #undef FUNCTION
+
+  #undef CAPABILITY
+
+
+  // Run event generator
+  #define CAPABILITY HardScatteringEvent
+    #define FUNCTION generateEventPythia_THDM
+    START_FUNCTION(Pythia_default::Pythia8::Event)
+    NEEDS_MANAGER(RunMC, MCLoopInfo)
+    NEEDS_CLASSES_FROM(Pythia, default)
+    DEPENDENCY(HardScatteringSim, Py8Collider_defaultversion)
+    DEPENDENCY(EventWeighterFunction, EventWeighterFunctionType)
+    ALLOW_MODELS(THDM, THDMatQ)
+    ALLOW_MODELS(ColliderBit_SLHA_file_model, ColliderBit_SLHA_scan_model)
+    #undef FUNCTION
+
+    #define FUNCTION generateEventPythia_THDM_HEPUtils
+    START_FUNCTION(HEPUtils::Event)
+    NEEDS_MANAGER(RunMC, MCLoopInfo)
+    NEEDS_CLASSES_FROM(Pythia, default)
+    DEPENDENCY(HardScatteringSim, Py8Collider_defaultversion)
+    DEPENDENCY(HardScatteringEvent, Pythia_default::Pythia8::Event)
+    DEPENDENCY(EventWeighterFunction, EventWeighterFunctionType)
+    #undef FUNCTION
+
+    #ifndef EXCLUDE_HEPMC
+      #define FUNCTION generateEventPythia_THDM_HepMC
+      START_FUNCTION(HepMC3::GenEvent)
+      NEEDS_MANAGER(RunMC, MCLoopInfo)
+      NEEDS_CLASSES_FROM(Pythia, default)
+      DEPENDENCY(HardScatteringSim, Py8Collider_defaultversion)
+      DEPENDENCY(HardScatteringEvent, Pythia_default::Pythia8::Event)
+      #undef FUNCTION
+    #endif
+
+  #undef CAPABILITY
+
+#undef MODULE

--- a/ColliderBit/scripts/collider_harvester.py
+++ b/ColliderBit/scripts/collider_harvester.py
@@ -30,7 +30,7 @@ exec(compile(open(toolsfile, "rb").read(), toolsfile, 'exec')) # Python 2/3 comp
 def main(argv):
 
     model_headers=set([])
-    ignore_model_headers=["SUSY.hpp", "SUSY_extras.hpp"]
+    ignore_model_headers=["SUSY.hpp", "SUSY_extras.hpp", "THDM.hpp"]
 
     # Handle command line options
     verbose = False

--- a/ColliderBit/src/models/SUSY_extras.cpp
+++ b/ColliderBit/src/models/SUSY_extras.cpp
@@ -216,6 +216,10 @@ namespace Gambit
       {
         result = Dep::SLHAFileNameAndContent->second;
       }
+      else if (ModelInUse("THDM") || ModelInUse("THDMatQ"))
+      {
+        result = Dep::THDM_spectrum->getSLHAea(1);
+      }
       else
       {
         // This can only happen if the ALLOW_MODELS list in SUSY.hpp has been changed
@@ -254,6 +258,10 @@ namespace Gambit
                ModelInUse("ColliderBit_SLHA_scan_model"))
       {
         result = Dep::SLHAFileNameAndContent->second;
+      }
+      else if (ModelInUse("THDM") || ModelInUse("THDMatQ"))
+      {
+        result = Dep::THDM_spectrum->getSLHAea(1);
       }
       else
       {

--- a/ColliderBit/src/models/THDM.cpp
+++ b/ColliderBit/src/models/THDM.cpp
@@ -1,0 +1,128 @@
+//   GAMBIT: Global and Modular BSM Inference Tool
+//   *********************************************
+///  \file
+///
+///  SUSY-specific sources for ColliderBit. TODO: I belive that the normalisation should match Pythia's
+///  TODO: All of the couplings as calculated in SpecBit are purely real/imaignary, so I am just taking their abs (so I don't have to care which it is)
+///  TODO: Three are left to zero as those ar enot present in the coupling table/papers so presumably should be zero
+///
+///  *********************************************
+///
+///  Authors (add name and date if you modify):
+///
+///  \author Chris Chang
+///  \date 2023
+///
+///  *********************************************
+
+#include "gambit/ColliderBit/getPy8Collider.hpp"
+#include "gambit/ColliderBit/generateEventPy8Collider.hpp"
+
+namespace Gambit
+{
+  namespace ColliderBit
+  {
+
+    // Get spectrum and decays for Pythia
+    //GET_SPECTRUM_AND_DECAYS_FOR_PYTHIA_NONSUSY(getSpectrumAndDecaysForPythia_THDM, THDM_spectrum)
+
+    void getSpectrumAndDecaysForPythia_THDM(SLHAstruct& result)
+    {
+      using namespace Pipes::getSpectrumAndDecaysForPythia_THDM;
+      result.clear();
+      /* Get decays */
+      result = Dep::decay_rates->getSLHAea(2);
+      /* Get spectrum */
+      SLHAstruct slha_spectrum = Dep::THDM_spectrum->getSLHAea(2);
+
+      // Add in the Higgs Couplings
+      const HiggsCouplingsTable higgs_tbl = *Dep::Higgs_Couplings;
+      CouplingTable thdm_tbl = *Dep::couplingtable_THDM;
+      
+      // name of each scalar
+      const static std::string h = "h0_1", H = "h0_2", A = "A0", Hp = "H+", Hm = "H-", G = "G0", Gp = "G+", Gm = "G-";
+
+      double H1_coup2d = sqrt(higgs_tbl.C_ss2.at(0));
+      double H1_coup2u = sqrt(higgs_tbl.C_cc2.at(0));
+      double H1_coup2l = sqrt(higgs_tbl.C_mumu2.at(0));
+      double H1_coup2Z = higgs_tbl.C_ZZ.at(0);
+      double H1_coup2W = higgs_tbl.C_WW.at(0);
+
+      double H2_coup2d = sqrt(higgs_tbl.C_ss2.at(1));
+      double H2_coup2u = sqrt(higgs_tbl.C_cc2.at(1));
+      double H2_coup2l = sqrt(higgs_tbl.C_mumu2.at(1));
+      double H2_coup2Z = higgs_tbl.C_ZZ.at(1);
+      double H2_coup2W = higgs_tbl.C_WW.at(1);
+      double H2_coup2H1Z = (higgs_tbl.C_hiZ.at(1)).at(0);
+      double H2_coup2HchgW = abs(thdm_tbl.get({h,Hp,Gm})); // TODO: Check
+
+      double A3_coup2d = sqrt(higgs_tbl.C_ss2.at(2));
+      double A3_coup2u = sqrt(higgs_tbl.C_cc2.at(2));
+      double A3_coup2l = sqrt(higgs_tbl.C_mumu2.at(2));
+      double A3_coup2Z = higgs_tbl.C_ZZ.at(2);
+      double A3_coup2W = higgs_tbl.C_WW.at(2);
+      double A3_coup2H1Z = (higgs_tbl.C_hiZ.at(2)).at(0);
+      double A3_coup2H2Z = (higgs_tbl.C_hiZ.at(2)).at(1);
+      double A3_coup2HchgW = abs(thdm_tbl.get({A,Hp,Gm})); // TODO: Check
+
+      double tanb = Dep::THDM_spectrum->get(Par::dimensionless, "tanb");
+      double Hchg_coup2H1W = abs(thdm_tbl.get({h,Hp,Gm})); // TODO: Check
+      double Hchg_coup2H2W = abs(thdm_tbl.get({H,Hp,Gm})); // TODO: Check
+
+      double H1_coup2Hchg = abs(thdm_tbl.get({h,Hp,Hm})); // TODO: Check
+      double H2_coup2Hchg = abs(thdm_tbl.get({H,Hp,Hm})); // TODO: Check
+      double H2_coup2H1H1 = abs(thdm_tbl.get({h,h,H})); // TODO: Check
+      double H2_coup2A3A3 = abs(thdm_tbl.get({H,A,A})); // TODO: Check
+      double H2_coup2A3H1 = 0.0; // TODO: Should this be zero?
+      double A3_coup2H1H1 = 0.0; // TODO: Should this be zero?
+      double A3_coup2Hchg = 0.0; // TODO: Should this be zero?
+
+      SLHAea_add_block(slha_spectrum, "THDMCOUPLINGS");
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 1, H1_coup2d, "HiggsH1:coup2d", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 2, H1_coup2u, "HiggsH1:coup2u", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 3, H1_coup2l, "HiggsH1:coup2l", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 4, H1_coup2Z, "HiggsH1:coup2Z", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 5, H1_coup2W, "HiggsH1:coup2W", true);
+
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 6, H2_coup2d, "HiggsH2:coup2d", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 7, H2_coup2u, "HiggsH2:coup2u", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 8, H2_coup2l, "HiggsH2:coup2l", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 9, H2_coup2Z, "HiggsH2:coup2Z", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 10, H2_coup2W, "HiggsH2:coup2W", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 11, H2_coup2H1Z, "HiggsH2:coup2H1Z", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 12, H2_coup2HchgW, "HiggsH2:coup2HchgW", true);
+
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 13, A3_coup2d, "HiggsA3:coup2d", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 14, A3_coup2u, "HiggsA3:coup2u", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 15, A3_coup2l, "HiggsA3:coup2l", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 16, A3_coup2Z, "HiggsA3:coup2Z", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 17, A3_coup2W, "HiggsA3:coup2W", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 18, A3_coup2H1Z, "HiggsA3:coup2H1Z", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 19, A3_coup2H2Z, "HiggsA3:coup2H2Z", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 20, A3_coup2HchgW, "HiggsA3:coup2HchgW", true);
+
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 21, tanb, "HiggsHchg:tanBeta", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 22, Hchg_coup2H1W, "HiggsHchg:coup2H1W", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 23, Hchg_coup2H2W, "HiggsHchg:coup2H2W", true);
+
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 24, H1_coup2Hchg, "HiggsH1:coup2Hchg", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 25, H2_coup2Hchg, "HiggsH2:coup2Hchg", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 26, H2_coup2H1H1, "HiggsH2:coup2H1H1", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 27, H2_coup2A3A3, "HiggsH2:coup2A3A3", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 28, H2_coup2A3H1, "HiggsH2:coup2A3H1", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 29, A3_coup2H1H1, "HiggsA3:coup2H1H1", true);
+      SLHAea_add(slha_spectrum, "THDMCOUPLINGS", 30, A3_coup2Hchg, "HiggsA3:coup2Hchg", true);
+
+      result.insert(result.begin(), slha_spectrum.begin(), slha_spectrum.end());
+    }
+
+
+    // Get Monte Carlo event generator
+    GET_SPECIFIC_PYTHIA(getPythia_THDM, Pythia_default, /* blank MODEL_EXTENSION argument */ )
+    GET_PYTHIA_AS_BASE_COLLIDER(getPythiaAsBase_THDM)
+
+    // Run event generator
+    GET_PYTHIA_EVENT(generateEventPythia_THDM, Pythia_default::Pythia8::Event)
+
+  }
+}

--- a/Elements/src/thdm_slhahelp.cpp
+++ b/Elements/src/thdm_slhahelp.cpp
@@ -18,6 +18,9 @@
 ///          (gonzalo@physik.rwth-aachen.de)
 ///  \date 2021 Mar
 ///
+///  \author Chris Chang
+///  \date 2023 Sep
+///
 ///  *********************************************
 
 #include "gambit/Elements/thdm_slhahelp.hpp"
@@ -59,11 +62,12 @@ namespace Gambit
         const double g = thdmspec.get(Par::dimensionless,"g1");
         const double g_prime = thdmspec.get(Par::dimensionless,"g2");
         const double g_3 = thdmspec.get(Par::dimensionless,"g3");
+        const double vev = thdmspec.get(Par::mass1, "vev");
 
         // begin filling the SLHA
 
         // model selection block(10 = THDM)
-        SLHAea_add_block(slha, "MODSEL");;
+        SLHAea_add_block(slha, "MODSEL");
         SLHAea_add(slha, "MODSEL", 0, 10, "THDM", true);
         SLHAea_add(slha, "MODSEL", 1, 10, "THDM", true);
         
@@ -98,16 +102,24 @@ namespace Gambit
         SLHAea_add(slha, "MINPAR", 21, cba, "cos(b-a)", true);
 
         // physical mass parameters
-        SLHAea_add_block(slha, "MASS");
+        //SLHAea_add_block(slha, "MASS"); // commented this out because it is causing a repeat of the MASS block
         SLHAea_add(slha, "MASS", 24, MW, "MW", true);
         SLHAea_add(slha, "MASS", 25, m_h, "Mh0_1", true);
         SLHAea_add(slha, "MASS", 35, m_H, "Mh0_2", true);
         SLHAea_add(slha, "MASS", 36, m_A, "MA0", true);
         SLHAea_add(slha, "MASS", 37, m_Hp, "MHc", true);
 
+        // Adding in some entries in the HMIX Block
+        SLHAea_add_block(slha, "HMIX", thdmspec.GetScale());
+        SLHAea_add(slha, "HMIX", 1, sqrt(m12_2), "mu", true);
+        SLHAea_add(slha, "HMIX", 2, tanb, "tanb", true);
+        SLHAea_add(slha, "HMIX", 3, vev, "vev", true);
+        SLHAea_add(slha, "HMIX", 4, m_A*m_A, "mA^2", true);
+
         // angle alpha
         SLHAea_add_block(slha, "ALPHA");
-        SLHAea_add(slha, "ALPHA", 0, alpha, "alpha", true);
+        //SLHAea_add(slha, "ALPHA", 0, alpha, "alpha", true);
+        slha["ALPHA"][""] << alpha << "# alpha";// Pythia expects it is without an index, which is very odd, and different to how it expects all other parameters in the slha
         
         SLHAea_add_block(slha, "YU1");
         SLHAea_add_block(slha, "YD1");

--- a/yaml_files/THDM_ColliderTest.yaml
+++ b/yaml_files/THDM_ColliderTest.yaml
@@ -1,0 +1,348 @@
+##########################################################################
+## GAMBIT configuration for the following                               ##
+##                                                                      ##
+## Models: THDM, THDMI, THDMII, THDMLS, THDMflipped                     ##
+##                                                                      ##
+## Includes all compatible likelihoods:                                 ##
+## theoretical, collider, electroweak, flavour                          ##
+##                                                                      ##
+## Requires backends:                                                   ##
+## thdmc, SuperISO, HiggsBounds, HiggsSignals, HEPLike                  ##
+##                                                                      ##
+## Author: A.S. Woodcock                                                ##
+## Date: 22/JUL/2022                                                    ##
+##                                                                      ##
+##########################################################################
+
+
+Parameters:
+    StandardModel_SLHA2: !import include/StandardModel_SLHA2_defaults.yaml
+
+    THDMI:
+
+      lambda1:
+          range: [5, 13]
+          prior_type: pow
+          power: 6
+          shift: -5
+          output_scaled_values: false
+          # scale: 0.01
+      lambda2:
+          range: [0, 13]
+          prior_type: pow
+          power: 6
+          # scale: 0.01
+      lambda3:
+          range: [-13, 13]
+          prior_type: flat
+      lambda4:
+          range: [-13, 13]
+          prior_type: flat
+      lambda5:
+          range: [-13, 13]
+          prior_type: flat
+      lambda6:
+          fixed_value: 0.0
+      lambda7:
+          fixed_value: 0.0
+      m12_2:
+          ranges: [-1e1, -1e0, 1e6, 1e10]
+          prior_type: double_log_flat_join
+      tanb:
+          range: [0.03, 320]
+          prior_type: flat
+
+
+#################################
+##     PRINTER SELECTION       ##
+#################################
+
+
+Printer:
+
+  printer: cout
+
+#################################
+##     SCANNER SELECTION       ##
+#################################
+
+
+Scanner:
+
+  use_scanner: random
+
+  scanners:
+
+    random:
+      plugin: random
+      point_number: 1
+      like:  LogLike
+
+#################################
+##  OBSERVABLES / LIKELIHOODS  ##
+#################################
+
+
+ObsLikes:
+
+
+  #-------------------------------------#
+  #      COLLIDER LIKELIHOODS           #
+  #-------------------------------------#
+
+  # ### NOTE
+  # # LHC & LEP likelihoods
+  # # Coupling Squared input structs are filled by colliderBit,
+  # # then chi^2 are extracted directly from HS & HB
+
+  # # HiggsBounds 5.8.0 likelihood
+  # - capability: LEP_Higgs_LogLike
+  #   function: calc_HB_5_LEP_LogLike
+  #   purpose: LogLike
+
+  # # HiggsSignals 2.5.0 likelihood
+  # - capability: LHC_Higgs_LogLike
+  #   function: calc_HS_2_LHC_LogLike
+  #   purpose: LogLike
+  
+  # Calculate the LHC likelihood
+  - purpose:    LogLike
+    capability: LHC_Combined_LogLike
+  
+  - purpose:    Observable
+    capability: LHC_LogLike_per_analysis
+
+  - purpose:    Observable
+    capability: LHC_signals
+
+  - purpose:    Observable
+    capability: LHCEventLoopInfo
+
+
+#################################
+##          OBSERVABLES        ##
+#################################
+
+  # entire 2HDM spectrum
+  - capability: THDM_spectrum
+    type: map_str_dbl
+    purpose: Observable
+
+  # # 2HDM decay rates and branching ratios
+  # - capability: all_BFs
+  #   purpose: Observable
+
+
+
+
+###################################
+##  Likelihood/Observable Rules  ##
+###################################
+
+
+Rules:
+
+  - capability: THDM_spectrum
+    type: map_str_dbl
+    options:
+      print_minimal_yukawas: true
+
+  - capability: THDM_spectrum
+    type: Spectrum
+    function: get_THDM_spectrum_tree #get_THDM_spectrum_FS
+    
+  - capability: couplingtable_THDM
+    type: CouplingTable
+    function: get_coupling_table_using_physical_basis
+
+  - capability: decay_rates
+    function: all_decays
+    
+  # Pass an SLHA2 spectrum to Pythia
+  - capability: SpectrumAndDecaysForPythia
+    function: getSpectrumAndDecaysForPythia_THDM
+    options:
+      slha_version: 2
+      write_summary_to_log: false
+      
+  # Choose to where to get cross-sections from
+  - capability: TotalCrossSection
+    function: getEvGenCrossSection_as_base
+
+  # Just use unweighted cross-sections
+  - capability: EventWeighterFunction
+    function: setEventWeight_unity
+
+  # Choose where to get scattering events from
+  - capability: HardScatteringEvent
+    type: Pythia_default::Pythia8::Event
+    function: generateEventPythia_THDM
+
+  - capability: HardScatteringEvent
+    type: HEPUtils::Event
+    function: generateEventPythia_THDM_HEPUtils
+
+  
+  # Choose colliders to simulate and their convergence settings, and pick analyses to run with each collider.
+  - capability: RunMC
+    function: operateLHCLoop
+    options:
+      silenceLoop: false
+      LHC_13TeV:
+        min_nEvents: 10000
+        max_nEvents: 50000
+        events_between_convergence_checks: 5000
+        target_fractional_uncert: 0.3
+        halt_when_systematic_dominated: true
+        all_analyses_must_converge: false
+        all_SR_must_converge: false
+        maxFailedEvents: 100
+        analyses:
+          - CMS_13TeV_1LEPbb_36invfb # TODO I just chose a random analysis for testing, probably doesnt have sensitivity to THDM
+          - ATLAS_13TeV_4LEP_139invfb
+          - ATLAS_13TeV_MONOJET_139infb
+          - CMS_13TeV_MultiLEP_137invfb
+
+  # Choose Monte Carlo event simulator and options.
+  - capability:  HardScatteringSim
+    type: Py8Collider_defaultversion
+    function: getPythia_THDM
+    options:
+      LHC_13TeV:
+        xsec_veto: 0.0001
+        partonOnly: false
+        jet_collections:
+          antikt_R04:
+            algorithm: antikt
+            R: 0.4
+            recombination_scheme: E_scheme
+            strategy: Best
+        jet_collection_taus: antikt_R04
+        pythia_settings:
+          - Beams:eCM = 13000
+          - Next:numberShowProcess = 1
+          - Print:quiet = off
+          - Random:setSeed = on
+          - PartonLevel:MPI = off
+          - PartonLevel:ISR = on
+          - PartonLevel:FSR = on
+          - HadronLevel:all = on
+          #- SUSY:all = off
+          - Higgs:useBSM = on
+          #- HiggsBSM:all = on # TODo Would want to specify exactly which processes we want turned on
+          - HiggsBSM:qg2H1q = on
+          - HiggsBSM:qg2H2q = on
+          - HiggsBSM:gg2H1bbbar = on
+          - HiggsBSM:qqbar2H1bbbar = on
+          - HiggsBSM:gg2H2bbbar = on
+          - HiggsBSM:qqbar2H2bbbar = on
+          - HiggsBSM:qg2A3q = on
+          - HiggsBSM:gg2A3bbbar = on
+          - HiggsBSM:qqbar2A3bbbar = on
+          - SLHA:minMassSM = 20 # TODO I am setting this lower than the default of 100 to see if this fixes Pythia ignoring the decay table for A0
+          - Init:showChangedSettings = on
+          - Init:showChangedParticleData = on
+          - TauDecays:mode = 0
+          - TimeShower:pTmin = 2
+          #- SLHA:verbose = 3
+
+  # Choose LHC likelihood form and options.
+  - capability: LHC_LogLikes
+    # Choose not to use the FullLikes backend.
+    # function: calc_LHC_LogLikes
+    # Choose to use the FullLikes backend when applicable
+    function: calc_LHC_LogLikes_full
+    backends:
+    - {group: lnlike_marg_poisson, capability: lnlike_marg_poisson_lognormal_error}
+    options:
+      use_covariances: true
+      use_marginalising: false
+      combine_SRs_without_covariances: false
+      nuisance_prof_initstep: 0.1
+      nuisance_prof_convtol: 0.01
+      nuisance_prof_maxsteps: 10000
+      nuisance_prof_convacc: 0.01
+      nuisance_prof_simplexsize: 1e-5
+      nuisance_prof_method: 6
+      nuisance_prof_verbosity: 0
+      # covariance_marg_convthres_abs: 0.05
+      # covariance_marg_convthres_rel: 0.05
+      # covariance_nsamples_start: 1000000
+
+  # Options for how the combined LHC loglike should be calculated
+  - capability: LHC_Combined_LogLike
+    options:
+      write_summary_to_log: false
+      cap_loglike: false
+      cap_loglike_individual_analyses: false
+      # skip_analyses:
+  
+
+  #- capability: all_BFs
+  #  function: get_decaytable_as_map
+  #  options:
+  #    skip_particles: ['H-','W+','W-','Z0','e+_2','e+_3','e-_2','e-_3','mu+','mu-','pi+','pi-','pi0','tau+','tau-','tbar','u_3','ubar_3']
+  #    print_BF_error: False
+  #    print_as_widths: True
+
+  - capability: Higgs_Couplings
+    function: THDM_higgs_couplings_2HDMC
+
+  - capability: Reference_SM_Higgs_decay_rates
+    function: Ref_SM_Higgs_decays_THDM
+
+  - capability: Reference_SM_other_Higgs_decay_rates
+    function: Ref_SM_other_Higgs_decays_THDM
+
+  - capability: Reference_SM_A0_decay_rates
+    function: Ref_SM_A0_decays_THDM
+
+  - capability: t_decay_rates
+    function: t_decays_THDM
+
+
+#########################
+# Logging setup
+#########################
+
+
+Logger:
+
+  redirection:
+    [Debug] :  "debug.log"
+    [Default] :  "default.log"
+    [DecayBit] :  "DecayBit.log"
+    [PrecisionBit] :  "PrecisionBit.log"
+    [ColliderBit] :  "ColliderBit.log"
+    [SpecBit] :  "SpecBit.log"
+    [Dependency Resolver] :  "dep_resolver.log"
+    [Scanner]:  "Scanner.log"
+
+
+##########################
+# Name/Value Section
+##########################
+
+
+KeyValues:
+
+  print_scanID: false
+
+  likelihood:
+    print_invalid_points: false
+    # model_invalid_for_lnlike_below: -1e6
+    # model_invalid_for_lnlike_below_alt: -5e5
+    # disable_print_for_lnlike_below: -4e4
+    debug: false
+
+  dependency_resolution:
+    prefer_model_specific_functions: true
+    use_old_routines: false
+
+  exceptions:
+    dependency_resolver_error: fatal
+    dependency_resolver_warning: non-fatal
+    core_warning: fatal
+
+  default_output_path: "runs/THDM"
+  debug: true


### PR DESCRIPTION
Replacing my old PR with this new one since that was very out of date with the current state of the THDM_development branch.

This lets the user run Pythia events for THDM models. It now makes use of Alex's new Coupling Table storing the different Higgs couplings.

Codewise this is now fully working, but would be good to validate against a THDM sensitive collider search to be sure all the coupling normalisations are correct.

Happy for it to be merged after the THDM runs, since it was only going to be used in post-processing.