### PR TITLE
Small MPI fix for three python scanners.

### DIFF
--- a/ScannerBit/src/scanners/python/plugins/gambit_scipy.py
+++ b/ScannerBit/src/scanners/python/plugins/gambit_scipy.py
@@ -7,8 +7,6 @@ from utils import copydoc, version, with_mpi
 import numpy as np
 from itertools import product
 from collections import OrderedDict
-if with_mpi:
-    from utils import MPIPool, MPI
 
 try:
     import scipy.optimize

--- a/ScannerBit/src/scanners/python/plugins/gambit_ultranest.py
+++ b/ScannerBit/src/scanners/python/plugins/gambit_ultranest.py
@@ -6,7 +6,9 @@ Ultranest scanners
 import pickle
 import numpy as np
 from packaging.version import parse    
-from utils import copydoc, version, get_directory, store_pt_data
+from utils import copydoc, version, get_directory, store_pt_data, with_mpi
+if with_mpi:
+    from utils import MPI
 
 try:
     import ultranest

--- a/ScannerBit/src/scanners/python/plugins/gambit_zeus.py
+++ b/ScannerBit/src/scanners/python/plugins/gambit_zeus.py
@@ -7,7 +7,7 @@ import numpy as np
 import pickle
 from utils import copydoc, version, get_directory, with_mpi
 if with_mpi:
-    from utils import MPIPool, MPI
+    from utils import MPIPool
 
 try:
     import zeus


### PR DESCRIPTION
Added missing MPI import for gambit_ultranest scanner. Removed unnecessary MPI import for gambit_scipy and gambit_zeus.