### PR TITLE
Scanner Standalone fix

### DIFF
--- a/cmake/executables.cmake
+++ b/cmake/executables.cmake
@@ -87,6 +87,8 @@ if(EXISTS "${PROJECT_SOURCE_DIR}/ScannerBit/")
   else()
     # Make sure the printers compile OK if the rest of GAMBIT is missing
     target_compile_definitions(Printers PRIVATE SCANNER_STANDALONE)
+    target_compile_definitions(Logs PRIVATE SCANNER_STANDALONE)
+    target_compile_definitions(Utils PRIVATE SCANNER_STANDALONE)
   endif()
   add_dependencies(standalones ScannerBit_standalone)
 endif()


### PR DESCRIPTION
Somehow, the baseprinter.hpp header got included into the Logs and Utils files.  This is a problem for the ScannerBit standalone (e.g. pyscannerbit) since those modules are not compiled with "SCANNER_STANDALONE" defined when the rest of Gambit is missing (but the Printer module is compile with the definition).  So, I set "SCANNER_STANDALONE" for the Logs and Utils modules if the rest of Gambit does exist.