### PR TITLE
Add a try catch block to FullLikes backend

### DIFF
--- a/Backends/src/frontends/ATLAS_FullLikes_1_0.cpp
+++ b/Backends/src/frontends/ATLAS_FullLikes_1_0.cpp
@@ -48,8 +48,11 @@ BE_NAMESPACE
     }
     catch (...)
     {
-      invalid_point().raise(LOCAL_INFO, "ATLAS FullLikes has failed on this point (perhaps in the scipy optimise).");
+      invalid_point().raise("ATLAS FullLikes has failed on this point (perhaps in the scipy optimise).");
     }
+
+    // Squash a warning about no return
+    return 0.0;
   }
 #else
   double FullLikes_Evaluate(std::map<str,double>& SRsignal, const str& ana_name)


### PR DESCRIPTION
This is a simple PR to put the call to the ATLAS fulllikes backend into a try catch block. This has not been a problem thus far in GAMBIT, but I found from external calls to this backend that the scipy optimisation can fail in some cases, and this should be caught properly in GAMBIT.

Listing @anderkve as reviewer, but feel free to change as you wish. 