### PR TITLE
Update error message to be more clear when running with -b flag

### DIFF
--- a/Backends/include/gambit/Backends/backend_macros.hpp
+++ b/Backends/include/gambit/Backends/backend_macros.hpp
@@ -284,7 +284,9 @@ namespace Gambit                                                                
             << "which is supposed to contain the factory for class " << std::endl               \
             << fixns(STRINGIFY(BARENAME) STRINGIFY(CONVERT_VARIADIC_ARG(ARGS)))<<", "<<std::endl\
             << "is missing or catastrophically broken." << std::endl                            \
-            << "Fix or find that backend yo -- or don't use the type." << std::endl;            \
+            << "If running gambit with the -b flag, this backend is required to " << std::endl  \
+            << "run this yaml file or check what other backends are also required." << std::endl\
+            << "Otherwise, fix or find that backend -- or don't use the type." << std::endl;    \
         backend_error().raise(LOCAL_INFO BOOST_PP_COMMA() err.str());                           \
         return NULL;                                                                            \
       }                                                                                         \


### PR DESCRIPTION
This is a very simple PR to change one error message. It closes #507 . It is just making a little clearer that when running with the -b flag, and a BOSSed backend like pythia is not built, that this is in fact needed for this yaml file (and that you cannot see what other backends are required until you build this backend).

Alternatively, if you think that the error message is already clear enough, we can just delete that issue, and this branch.

I have not set a reviewer, we can decide who wants to review in the next Core meeting.