### PR TITLE
Allow passing BOSS compiler to cmake.

### DIFF
--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -698,10 +698,16 @@ macro(BOSS_backend_full name backend_version ${ARGN})
       set(BOSS_includes_Eigen3 "-I${EIGEN3_INCLUDE_DIR}")
     endif()
 
-    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-      set(BOSS_castxml_cc "--castxml-cc=${CMAKE_CXX_COMPILER}")
-    elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
-      set(BOSS_castxml_cc "")
+    # Set the BOSS castxml compiler to the cxx compiler
+    # If it is passed by the user, add on "castxml-cc=" for BOSS
+    if (NOT DEFINED BOSS_castxml_compiler)
+      if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        set(BOSS_castxml_cc "--castxml-cc=${CMAKE_CXX_COMPILER}")
+      elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+        set(BOSS_castxml_cc "")
+      endif()
+    else()
+      set(BOSS_castxml_cc "--castxml-cc=${BOSS_castxml_compiler}")
     endif()
 
     # Parse command line options from optional arguments


### PR DESCRIPTION
Very simple build change. Lets the user pass the compiler to use for compiling castxml (used when BOSS runs).

```
-DBOSS_castxml_compiler=/usr/bin/g++-10
```

This is useful because we often find that specific compiler versions struggle with castxml, and the castxml compiler can be different to the one used to compile the rest of gambit.

I have not set a reviewer. If no one chooses to pick it up, I will ask someone to review.
