### PR TITLE
Fix invalid escape sequence

### DIFF
--- a/ScannerBit/include/gambit/ScannerBit/plugin_interface.hpp
+++ b/ScannerBit/include/gambit/ScannerBit/plugin_interface.hpp
@@ -176,7 +176,7 @@ namespace Gambit
                 template <typename... args>
                 auto operator()(args&... params) -> typename find_variadic_type <void (args...), T...>::ret_type
                 {
-                    static_assert(find_variadic_type <void (args...), T...>::value, "\n\033[00;31;1mPlugin Interface:  Entered argument types do not match any of the plugin mains' argument types.\033[00m\n");
+                    static_assert(find_variadic_type <void (args...), T...>::value, "\n\u001B[00;31;1mPlugin Interface:  Entered argument types do not match any of the plugin mains' argument types.\u001B[00m\n");
                     return Plugin_Main_Interface_Base<typename find_variadic_type <void (args...), T...>::func_type>::operator()(params...);
                 }
             };


### PR DESCRIPTION
This closes #541

This PR replaces the invalid escape sequence `\033` by `\u001B`, which my version of clang accepts

I have tested it with clang 18.1.3 on ubuntu 24.04