### PR TITLE
Issue #517: MontePythonLike and pybind11 issue

### DIFF
--- a/Backends/src/frontends/MontePythonLike_3_5_0.cpp
+++ b/Backends/src/frontends/MontePythonLike_3_5_0.cpp
@@ -48,7 +48,12 @@
     std::vector<str> get_MP_available_likelihoods()
     {
       pybind11::list avail_likes = MontePythonLike.attr("get_available_likelihoods")(backendDir);
-      return avail_likes.cast<std::vector<str>>();
+      std::vector<str> avail_likes_output;
+      for (size_t i = 0 ; i < avail_likes.size();i++)
+      {
+        avail_likes_output.push_back(avail_likes[i].cast<str>());
+      }
+      return avail_likes_output;
     }
 
     /// convenience function to check compatibility of likelihoods and CLASS version in use

--- a/yaml_files/CosmoBit_quickStart.yaml
+++ b/yaml_files/CosmoBit_quickStart.yaml
@@ -224,6 +224,8 @@ Rules:
   #- capability: classy_final_input
   #  function: set_classy_input
 
+  - capability: N_ur
+    function: get_N_ur
 
   # ----------- 7.c) "Global" (CossmoBit-wide) settings ------------
 


### PR DESCRIPTION
For issue #517. Changed the pybingd11 casting of a list of strings to vector of strings in MontepythonLike. Also had to update the relevant yaml file with a specific function to use for one of the capabilities.

