### PR TITLE
fixed bug in WIMP_annihilation::B

### DIFF
--- a/Elements/src/wimp_types.cpp
+++ b/Elements/src/wimp_types.cpp
@@ -42,8 +42,8 @@ namespace Gambit
     double WIMP_annihilation::B(const std::string& channel) const
     {
        double out;
-       auto it = a.find(channel);
-       if(it==a.end())
+       auto it = b.find(channel);
+       if(it==b.end())
        {
           out = 0;
        }


### PR DESCRIPTION
Function returned leading s-wave (const) rather than v^2 part