### PR TITLE
Fix bugs in the Initial cross-section, and pythia banner printing.

### DIFF
--- a/ColliderBit/include/gambit/ColliderBit/colliders/Pythia8/Py8Collider.hpp
+++ b/ColliderBit/include/gambit/ColliderBit/colliders/Pythia8/Py8Collider.hpp
@@ -178,7 +178,7 @@ namespace Gambit
 
           // Create new _pythiaInstance from _pythiaBase
           if (_pythiaInstance) delete _pythiaInstance;
-          _pythiaInstance = new PythiaT(_pythiaBase->settings, _pythiaBase->particleData);
+          _pythiaInstance = new PythiaT(_pythiaBase->settings, _pythiaBase->particleData, false);
 
           // Send along the SLHAea::Coll pointer, if it exists
           if (slhaea) _pythiaInstance->slhaInterface.slha.setSLHAea(slhaea);

--- a/ColliderBit/include/gambit/ColliderBit/generateEventPy8Collider.hpp
+++ b/ColliderBit/include/gambit/ColliderBit/generateEventPy8Collider.hpp
@@ -69,7 +69,7 @@ namespace Gambit
 
       static bool first = true;
       static str pythia_doc_path;
-      PythiaT pythia;
+      thread_local PythiaT pythia;
 
       // Setup the Pythia documentation path and print the banner once
       if (first)
@@ -129,7 +129,7 @@ namespace Gambit
         std::map<int, double> combined_process_xsec;
         std::map<int, double> combined_process_xsecErr;
 
-        #pragma omp parallel firstprivate(pythia, pythiaOptions)
+        #pragma omp parallel firstprivate(pythiaOptions)
         {
           // Add a thread-specific seed to this thread's copy of the Pythia options
           str seed = std::to_string(int(Random::draw() * 899990000.));
@@ -137,6 +137,7 @@ namespace Gambit
 
           try
           {
+            pythia.clear();
             pythia.init(pythia_doc_path, pythiaOptions, &slha);
           }
           catch (...)
@@ -146,6 +147,7 @@ namespace Gambit
             pythiaOptions.push_back("Random:seed = " + std::to_string(newSeedBase));
             try
             {
+              pythia.clear();
               pythia.init(pythia_doc_path, pythiaOptions, &slha);
             }
             catch (...)
@@ -303,7 +305,7 @@ namespace Gambit
     void NAME(initialxsec_container& result)                                                                                                  \
     {                                                                                                                                         \
       using namespace Pipes::NAME;                                                                                                            \
-      static SLHAstruct slha = *Dep::SpectrumAndDecaysForPythia;                                                                              \
+      SLHAstruct slha = *Dep::SpectrumAndDecaysForPythia;                                                                                     \
                                                                                                                                               \
       PerformInitialCrossSection_Pythia<PYTHIA_COLLIDER, PYTHIA_NS::Pythia8::Event>(result, slha, "", *runOptions);                           \
     }
@@ -312,7 +314,7 @@ namespace Gambit
     void NAME(initialxsec_container& result)                                                                                                  \
     {                                                                                                                                         \
       using namespace Pipes::NAME;                                                                                                            \
-      static SLHAstruct slha = *Dep::SpectrumAndDecaysForPythia;                                                                              \
+      SLHAstruct slha = *Dep::SpectrumAndDecaysForPythia;                                                                                     \
                                                                                                                                               \
       PerformInitialCrossSection_Pythia<PYTHIA_COLLIDER, PYTHIA_NS::Pythia8::Event>(result, slha, #MODEL_EXTENSION, *runOptions);             \
     }


### PR DESCRIPTION
This fixes 2 bugs:
- Incorrect usage of static in the Pythia initial cross-ections caused the spectrum not to be updated between parameter points
- Explicitly telling the pythia ininitialisation to not print the banner. Previously this was coverred by the silence loop option, but would not work for the initial Pythia cross-sections. 