### PR TITLE
Make hdf5 printers and build system more robust to hdf5 version differences

### DIFF
--- a/Printers/include/gambit/Printers/printers/hdf5printer/hdf5tools.hpp
+++ b/Printers/include/gambit/Printers/printers/hdf5printer/hdf5tools.hpp
@@ -44,6 +44,31 @@
 // HDF5
 #include <hdf5.h>
 
+// Compatibility shims for HDF5 API changes between 1.10 and 1.12+.
+// In 1.12 several functions gained an extra "fields" argument and the
+// link/object-info structs were renamed (H5L_info_t -> H5L_info2_t,
+// H5O_info_t -> H5O_info2_t). The unversioned names continue to work only
+// when -DH5_USE_110_API is set globally, but doing that affects every
+// translation unit that includes <hdf5.h> (including any backends or
+// contrib code), which is fragile. Instead we call the version-specific
+// symbols directly via the GAMBIT_H5_* aliases below.
+#if H5_VERSION_GE(1, 12, 0)
+  #define GAMBIT_H5L_INFO_T  H5L_info2_t
+  #define GAMBIT_H5O_INFO_T  H5O_info2_t
+  // H5Oget_info_by_name3 has an extra "fields" argument selecting which
+  // fields to populate; H5O_INFO_BASIC fills the .type field, which is all
+  // we need to distinguish groups from datasets.
+  #define GAMBIT_H5OGET_INFO_BY_NAME(loc_id, name, info_ptr, plist) \
+            H5Oget_info_by_name3((loc_id), (name), (info_ptr), H5O_INFO_BASIC, (plist))
+  #define GAMBIT_H5LITERATE H5Literate2
+#else
+  #define GAMBIT_H5L_INFO_T  H5L_info_t
+  #define GAMBIT_H5O_INFO_T  H5O_info_t
+  #define GAMBIT_H5OGET_INFO_BY_NAME(loc_id, name, info_ptr, plist) \
+            H5Oget_info_by_name((loc_id), (name), (info_ptr), (plist))
+  #define GAMBIT_H5LITERATE H5Literate
+#endif
+
 // Boost
 #include <boost/utility/enable_if.hpp>
 

--- a/Printers/src/printers/hdf5printer/hdf5_combine_tools.cpp
+++ b/Printers/src/printers/hdf5printer/hdf5_combine_tools.cpp
@@ -104,17 +104,17 @@ namespace Gambit
 
 
 
-            inline herr_t op_func (hid_t loc_id, const char *name_in, const H5L_info_t *,
+            inline herr_t op_func (hid_t loc_id, const char *name_in, const GAMBIT_H5L_INFO_T *,
                     void *operator_data)
             {
                 //herr_t          status;
                 herr_t          return_val = 0;
-                H5O_info_t      infobuf;
+                GAMBIT_H5O_INFO_T infobuf;
                 std::vector<std::string> &od = *static_cast<std::vector<std::string> *> (operator_data);
                 std::string name(name_in);
 
-                //status = H5Oget_info_by_name (loc_id, name.c_str(), &infobuf, H5P_DEFAULT);
-                H5Oget_info_by_name (loc_id, name.c_str(), &infobuf, H5P_DEFAULT);
+                //status = GAMBIT_H5OGET_INFO_BY_NAME (loc_id, name.c_str(), &infobuf, H5P_DEFAULT);
+                GAMBIT_H5OGET_INFO_BY_NAME (loc_id, name.c_str(), &infobuf, H5P_DEFAULT);
 
                 switch (infobuf.type)
                 {
@@ -144,17 +144,17 @@ namespace Gambit
                 return return_val;
             }
 
-            inline herr_t op_func_aux (hid_t loc_id, const char *name_in, const H5L_info_t *,
+            inline herr_t op_func_aux (hid_t loc_id, const char *name_in, const GAMBIT_H5L_INFO_T *,
                     void *operator_data)
             {
                 //herr_t          status;
                 herr_t          return_val = 0;
-                H5O_info_t      infobuf;
+                GAMBIT_H5O_INFO_T infobuf;
                 std::vector<std::string> &od = *static_cast<std::vector<std::string> *> (operator_data);
                 std::string name(name_in);
 
-                //status = H5Oget_info_by_name (loc_id, name.c_str(), &infobuf, H5P_DEFAULT);
-                H5Oget_info_by_name (loc_id, name.c_str(), &infobuf, H5P_DEFAULT);
+                //status = GAMBIT_H5OGET_INFO_BY_NAME (loc_id, name.c_str(), &infobuf, H5P_DEFAULT);
+                GAMBIT_H5OGET_INFO_BY_NAME (loc_id, name.c_str(), &infobuf, H5P_DEFAULT);
 
                 switch (infobuf.type)
                 {

--- a/Printers/src/printers/hdf5printer/hdf5tools.cpp
+++ b/Printers/src/printers/hdf5printer/hdf5tools.cpp
@@ -589,17 +589,16 @@ namespace Gambit {
       }
 
       // Iterator function for listing datasets in a group
-      herr_t group_ls(hid_t g_id, const char *name, const H5L_info_t* /*info*/, void *op_data)
+      herr_t group_ls(hid_t g_id, const char *name, const GAMBIT_H5L_INFO_T* /*info*/, void *op_data)
       {
           #ifdef HDF5_DEBUG
             //std::cout<<"group_ls: "<<name<<std::endl;
-            //std::cout<<info->type<<" "<<H5G_DATASET<<std::endl;
           #endif
           std::vector<std::string>* out = static_cast<std::vector<std::string>*>(op_data);
           // Only add names that correspond to datasets
-          H5G_stat_t statbuf;
-          H5Gget_objinfo(g_id, name, false, &statbuf);
-          if(statbuf.type == H5G_DATASET) out->push_back(name);
+          GAMBIT_H5O_INFO_T object_info;
+          herr_t err = GAMBIT_H5OGET_INFO_BY_NAME(g_id, name, &object_info, H5P_DEFAULT);
+          if(err >= 0 and object_info.type == H5O_TYPE_DATASET) out->push_back(name);
           return 0;
       }
 
@@ -614,7 +613,7 @@ namespace Gambit {
          }
 
          std::vector<std::string> out;
-         herr_t err = H5Literate(group_id, H5_INDEX_NAME, H5_ITER_NATIVE, NULL, group_ls, &out);
+         herr_t err = GAMBIT_H5LITERATE(group_id, H5_INDEX_NAME, H5_ITER_NATIVE, NULL, group_ls, &out);
 
          if(err<0)
          {
@@ -629,8 +628,8 @@ namespace Gambit {
       /// Check if an object in a file or group is a dataset
       bool isDataSet(hid_t loc_id, const std::string& name)
       {
-          H5O_info_t object_info;
-          herr_t err = H5Oget_info_by_name(loc_id, name.c_str(), &object_info, H5P_DEFAULT);
+          GAMBIT_H5O_INFO_T object_info;
+          herr_t err = GAMBIT_H5OGET_INFO_BY_NAME(loc_id, name.c_str(), &object_info, H5P_DEFAULT);
           if(err<0)
           {
               std::ostringstream errmsg;

--- a/cmake/optional.cmake
+++ b/cmake/optional.cmake
@@ -324,23 +324,57 @@ else()
   set (EXCLUDE_ROOT TRUE)
 endif()
 
-# Check for HDF5 libraries
+# Check for HDF5 libraries.
+# GAMBIT's HDF5 printers use serial HDF5 only; MPI coordination happens at
+# the GAMBIT level rather than through parallel HDF5 collective I/O. Force
+# the finder to pick the serial build even when a parallel build is also
+# present, which avoids accidentally pulling in MPI symbols/headers from
+# libhdf5 (a common source of breakage on macOS with mixed Homebrew/Anaconda
+# installs and on HPC modules).
+set(HDF5_PREFER_PARALLEL FALSE)
 find_package(HDF5 QUIET COMPONENTS C)
 if(HDF5_FOUND)
-  include_directories(${HDF5_INCLUDE_DIR})  # for older versions of cmake
-  include_directories(${HDF5_INCLUDE_DIRS}) # for newer cmake
+  # Mark HDF5 includes as SYSTEM so they don't generate warnings in
+  # downstream code and stay out of the way of GAMBIT's own headers.
+  include_directories(SYSTEM ${HDF5_INCLUDE_DIR})  # for older versions of cmake
+  include_directories(SYSTEM ${HDF5_INCLUDE_DIRS}) # for newer cmake
   message("-- Found HDF5 version: ${HDF5_VERSION}")
-  if (HDF5_VERSION VERSION_GREATER 1.12 OR HDF5_VERSION VERSION_EQUAL 1.12)
-      message("   Enforcing API macro mapping to HDF5 version 1.10.")
-      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DH5_USE_110_API")
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DH5_USE_110_API")
-  endif()
   message("   Found HDF5 libraries: ${HDF5_LIBRARIES}")
   if(VERBOSE)
     message(STATUS ${HDF5_INCLUDE_DIRS} ${HDF5_INCLUDE_DIR})
   endif()
+
+  # Sanity check: try to compile a small program that includes hdf5.h and
+  # links against the discovered libraries. This catches the common case
+  # where find_package mixes headers from one HDF5 install with libraries
+  # from another (e.g. Homebrew + Anaconda on macOS) before the user hits a
+  # cryptic compile or link error deep into the GAMBIT build.
+  include(CheckCSourceCompiles)
+  include(CMakePushCheckState)
+  cmake_push_check_state()
+  set(CMAKE_REQUIRED_INCLUDES  ${HDF5_INCLUDE_DIRS} ${HDF5_INCLUDE_DIR})
+  set(CMAKE_REQUIRED_LIBRARIES ${HDF5_LIBRARIES})
+  set(CMAKE_REQUIRED_QUIET TRUE)
+  check_c_source_compiles(
+    "#include <hdf5.h>
+     int main(void) {
+       hid_t plist = H5Pcreate(H5P_FILE_ACCESS);
+       H5Pclose(plist);
+       return 0;
+     }"
+    GAMBIT_HDF5_USABLE)
+  cmake_pop_check_state()
+  if(NOT GAMBIT_HDF5_USABLE)
+    message("${BoldCyan} X HDF5 was found by CMake (version ${HDF5_VERSION}) but a basic compile/link test failed.${ColourReset}")
+    message("    This often means the discovered headers and libraries come from different HDF5 installs")
+    message("    (e.g. Homebrew + Anaconda on macOS). Excluding hdf5printer and hdf5reader from this configuration.")
+    message("    To force a specific install, configure with -DHDF5_ROOT=/path/to/hdf5/prefix.")
+    set(HDF5_FOUND FALSE)
+    set(itch "${itch}" "hdf5printer" "hdf5reader")
+  endif()
 else()
   message("${BoldCyan} X No HDF5 C libraries found. Excluding hdf5printer and hdf5reader from GAMBIT configuration.${ColourReset}")
+  message("    To point to a specific HDF5 install, configure with -DHDF5_ROOT=/path/to/hdf5/prefix.")
   set(itch "${itch}" "hdf5printer" "hdf5reader")
 endif()
 


### PR DESCRIPTION
This PR adds some modifications to `Printers/` and to our CMake system, to make the GAMBIT build more robust to issues related to the API changes between different versions of the HDF5 library. 

Note that we should probably wait for PR https://github.com/GambitBSM/gambit/pull/582 to be merged first and pull that small change into this PR before merging this one. 


Summary of changes:

Changes to CMake system (cmake/optional.cmake):
  - Set `HDF5_PREFER_PARALLEL FALSE` before find_package so a parallel HDF5 install can't be silently preferred. GAMBIT's printers are serial. (MPI coordination is done on the GAMBIT side, not by the parallell HDF5 library.)
  - Switched `include_directories(...)` to `include_directories(SYSTEM ...)`.
  - Dropped the global `-DH5_USE_110_API`. (When not scoped, this would affect all our build targets, not just the GAMBIT code in `Printers`.)
  - Added a `check_c_source_compiles` test (`GAMBIT_HDF5_USABLE`) that compiles + links a small program against the discovered HDF5; if it fails, the printers get ditched with a clear
  hint to use `-DHDF5_ROOT=....` This should ensure that we catch the cases where different hdf5 libraries are mixed early in the configure process, rather that giving some cryptic compile/link error deep into the GAMBIT build.
  - Added a `-DHDF5_ROOT=...` hint to the not-found message.

  Changes to `Printers/` (so we no longer need `-DH5_USE_110_API`):
  - `Printers/include/gambit/Printers/printers/hdf5printer/hdf5tools.hpp`: added a small set of macros that maps `GAMBIT_H5L_INFO_T`, `GAMBIT_H5O_INFO_T`, `GAMBIT_H5OGET_INFO_BY_NAME(...)`
   and `GAMBIT_H5LITERATE` to the version-specific symbols (`H5Literate2`/`H5Oget_info_by_name3`/`H5O_info2_t`/`H5L_info2_t` on 1.12+, the unversioned forms on 1.10).
  - `Printers/src/printers/hdf5printer/hdf5tools.cpp`: `group_ls` no longer uses the deprecated `H5Gget_objinfo`/`H5G_stat_t` (now uses `GAMBIT_H5OGET_INFO_BY_NAME` + `H5O_TYPE_DATASET`);
  `lsGroup` uses `GAMBIT_H5LITERATE`; `isDataSet` uses the macros.
  - `Printers/src/printers/hdf5printer/hdf5_combine_tools.cpp`: `op_func`/`op_func_aux` updated to use the macros 
  
