### PR TITLE
Fix H5Fflush failure in hdf5_v1 printer with MultiNest

### DIFF
--- a/Printers/src/printers/hdf5printer/hdf5printer.cpp
+++ b/Printers/src/printers/hdf5printer/hdf5printer.cpp
@@ -1377,8 +1377,11 @@ namespace Gambit
         printer_error().raise(LOCAL_INFO, errmsg.str());
       }
 
-      // Tell the HDF5 library to flush everything to disk
-      herr_t err = H5Fflush(file_id, H5F_SCOPE_GLOBAL);
+      // Tell the HDF5 library to flush everything to disk.
+      // Auxiliary printers don't own a file handle (only the primary opens
+      // the HDF5 file in its constructor), so always flush via the primary's
+      // file_id. For the primary itself, primary_printer == this.
+      herr_t err = H5Fflush(primary_printer->file_id, H5F_SCOPE_GLOBAL);
       if(err<0)
       {
         std::ostringstream errmsg;


### PR DESCRIPTION
The hdf5_v1 printer aborted with "H5Fflush returned error value (-1)... not a file or file object" whenever a scanner explicitly called flush() on an auxiliary print stream. MultiNest hits this on its very first dumper callback, where it flushes the "txt" (Posterior) and "live" (LastLive) RA streams. Simple reproduction of the issue: On the master branch, run a scan with `spartan.yaml` set to use the `multinest` scanner and the `hdf5_v1` printer.

Root cause: only the primary HDF5Printer opens the HDF5 file and sets its file_id member; auxiliary printers inherit location_id, RA_location_id,and metadata_location_id from the primary but never initialise their own file_id. HDF5Printer::empty_sync_buffers() called H5Fflush(file_id, ...)unconditionally, so on an aux printer it was flushing an uninitialised hid_t.

Fix: route the flush through primary_printer->file_id. primary_printer defaults to "this" for the primary and is set to the actual primary in the aux constructor, so the same call is correct in both cases. This also makes the dumper's flush() calls actually useful (they now push HDF5's internal buffers to disk) instead of erroring out.

A test with `spartan.yaml` with `multinest` and `hdf5_v1` confirms that this fix works.

Closes #495.