### PR TITLE
Small depresolver efficiency tweaks

### DIFF
--- a/Core/include/gambit/Core/depresolver.hpp
+++ b/Core/include/gambit/Core/depresolver.hpp
@@ -38,6 +38,7 @@
 #include <vector>
 #include <map>
 #include <queue>
+#include <unordered_map>
 
 #include "gambit/Core/core.hpp"
 #include "gambit/Core/error_handlers.hpp"
@@ -267,6 +268,12 @@ namespace Gambit
 
         /// Output Vertex Infos
         std::vector<OutputVertex> outputVertices;
+
+        /// Map from vertex ID to outputVertices, populated at the end of
+        /// doResolution(). Lets getPurpose() / getCritical() do an O(1) lookup
+        /// instead of a linear scan (the latter is called per target vertex per
+        /// scan point)
+        std::unordered_map<VertexID, const OutputVertex*> outputVertexIndex;
 
         /// The central boost graph object
         MasterGraphType masterGraph;

--- a/Core/src/depresolver.cpp
+++ b/Core/src/depresolver.cpp
@@ -324,6 +324,16 @@ namespace Gambit
       // Get the scanID
       set_scanID();
 
+      // Build the vertex ID -> OutputVertex* map used by getPurpose() and
+      // getCritical(). outputVertices is finalised by this point and is never
+      // mutated again, so the pointers stored here remain valid.
+      outputVertexIndex.clear();
+      outputVertexIndex.reserve(outputVertices.size());
+      for (const OutputVertex& ov : outputVertices)
+      {
+        outputVertexIndex.emplace(ov.vertex, &ov);
+      }
+
       // Done
     }
 
@@ -702,10 +712,8 @@ namespace Gambit
     /// Return the purpose associated with a given functor.
     const str& DependencyResolver::getPurpose(VertexID v)
     {
-      for (const OutputVertex& ov : outputVertices)
-      {
-        if (ov.vertex == v) return ov.purpose;
-      }
+      auto it = outputVertexIndex.find(v);
+      if (it != outputVertexIndex.end()) return it->second->purpose;
       /// '__no_purpose' if the functor does not correspond to an ObsLike entry in the ini file.
       static const str none("__no_purpose");
       return none;
@@ -714,10 +722,8 @@ namespace Gambit
     /// Return whether a given functor is critical.
     bool DependencyResolver::getCritical(VertexID v)
     {
-      for (const OutputVertex& ov : outputVertices)
-      {
-        if (ov.vertex == v) return ov.critical;
-      }
+      auto it = outputVertexIndex.find(v);
+      if (it != outputVertexIndex.end()) return it->second->critical;
       /// critical can safely be false if the functor does not correspond to an ObsLike entry in the ini file.
       return false;
     }

--- a/Core/src/depresolver.cpp
+++ b/Core/src/depresolver.cpp
@@ -119,11 +119,15 @@ namespace Gambit
       for (std::tie(it, iend) = in_edges(vertex, graph);
           it != iend; ++it)
       {
-        if (std::find(myVertexList.begin(), myVertexList.end(), source(*it, graph)) == myVertexList.end() )
+        // Use the fact that insert() returns {iterator, true} when 
+        // the parent is new, in which case we recurse. (Should give 
+        // a O(log N) tree traversal rather than O(N) when using 
+        // std::find + insert.)
+        const VertexID parent = source(*it, graph);
+        if (myVertexList.insert(parent).second)
         {
-          myVertexList.insert(source(*it, graph));
-          getParentVertices(source(*it, graph), graph, myVertexList);
-        }
+          getParentVertices(parent, graph, myVertexList);          
+        }  
       }
     }
 


### PR DESCRIPTION
Two small efficiency tweaks to the depresolver. 

1) Construct a map from vertex ID to outputVertices after running doResolution. This means that functions getPurpose() and getCritical() can use this map for fast lookup.

2) In the recursive function getParentVertices, use the fact that std::set::insert returns a bool that indicates if the element existed or not to avoid doing first a std::find and then an insert on a std::set.