### PR TITLE
Require map form for grid_pts in grid / python_grid scanners

### DIFF
--- a/ScannerBit/src/scanners/python/plugins/grid.py
+++ b/ScannerBit/src/scanners/python/plugins/grid.py
@@ -27,9 +27,14 @@ class Grid(splug.scanner):
 Python implimentation of a simple grid scanner.  Evaluation points along a user-defined grid.
 
 YAML options:
-    grid_pts[10]: The number of points along each dimension on the grid.  A vector is given with each element corresponding to each dimension.
-    like:            Use the functors that correspond to the specified purpose.
-    parameters:      Specifies the order of parameters that corresponds to the grid points specified by the tag "grid_pts".
+    grid_pts:       A YAML map from "<model>::<param>" to integer, giving
+                    the number of grid points along each axis.  Every
+                    scanned parameter must appear as a key.  Example:
+                      grid_pts:
+                        NormalDist::mu: 5
+                        NormalDist::sigma: 3
+    like:           Use the functors that correspond to the specified purpose.
+    parameters:     Specifies the order of parameters that corresponds to the grid points specified by the tag "grid_pts".
 """
 
     # This specifies the version number.
@@ -44,60 +49,80 @@ YAML options:
 
         # You can access plugin data without using base class as follows:
         #
-        # # find mpi values
+        # # Find mpi values:
         # self.mpi_rank = scannerbit.rank()
         # self.mpi_size = scannerbit.numtasks()
-        # # gets dimension of hyper cube.
+        # 
+        # # Get dimension of hyper cube:
         # self.dim = splug.get_dimension()
-        
-        # # gets inifile value corresponding to "like" key
+        # 
+        # # Get inifile value corresponding to "like" key:
         # purpose = options["like"]
         #
-        # # or alternatively you can access the inifile options directly by:
+        # # Or alternatively, you can access the inifile options directly by:
         # purpose = splug.get_inifile_value("like", dtype=str)
         #
-        # # gets likelihood corresponding to the purpose "purpose"
+        # # Get likelihood corresponding to the purpose "purpose":
         # # self.like = splug.get_purpose(purpose)
         #
-        # # get grids pt number from inifile. Return a list of ints
-        # # grid_pts = options["grid_pts"]
-        
-        # # or alternatively you can access the inifile options directly by:
-        # # grid_pts = splug.get_inifile_value("grid_pts", dtype=list, etype=int)
-        
-        # # gets "parameters" infile value with a default of []. Returns a list of strings
-        # # parameters = splug.get_inifile_value("parameters", dtype=list, etype=str, default=list());
-        
-        if isinstance(grid_pts, int):
-            grid_points = [grid_pts] * self.dim
-        
-        if len(grid_pts) != self.dim:
-            raise RuntimeError("Grid scanner: The dimension of gambit ({0}) does not match the dimension of the inputed grid_pts ({1}).".format(self.dim, len(grid_pts)))
-        
-        self.size = np.prod(np.asarray(grid_pts))
-                
-        self.vecs=[]
+        # # Get grids pt number from inifile (returns a dict of {param: int}):
+        # # grid_pts = options["grid_pts"]   
+        # 
+        # # Or alternatively, you can access the inifile options directly by:
+        # # grid_pts = splug.get_inifile_value("grid_pts", dtype=dict)
 
-        # prepare the grid of points
-        if len(parameters) > 0:
-            param_names = self.parameter_names
-            # non-base class version:
-            # # get the parameters names from the prior
-            # param_names = splug.get_prior().getShownParameters()
-            
-            if len(param_names) != len(parameters):
-                raise RuntimeError("Grid scanner: The dimension of gambit ({0}) does not match the dimension of the inputed parameters ({1}).".format(len(param_names), len(parameters)))
-            
-            for param in param_names:
-                if param in parameters:
-                    self.vecs.append(np.linspace(0.0, 1.0, grid_pts[parameters.index(param)]))
-                else:
-                    raise RuntimeError("Grid scanner: parameter \"{0}\" is not provided.".format(param))
+        if not isinstance(grid_pts, dict):
+            raise RuntimeError(
+                "Grid scanner: \"grid_pts\" must be a YAML map from "
+                "\"<model>::<param>\" to integer, e.g.\n"
+                "    grid_pts:\n"
+                "      NormalDist::mu: 5\n"
+                "      NormalDist::sigma: 3")
 
-        else:
-            for n in grid_pts:
-                self.vecs.append(np.linspace(0.0, 1.0, n))
-    
+        param_names = self.parameter_names
+        # Non-base class version:
+        # # Get the parameters names from the prior:
+        # param_names = splug.get_prior().getShownParameters()
+
+        # Helper: splits a (possibly "+"-joined) shown parameter name into
+        # its constituent names, mirroring parse_sames() in the C++ grid
+        # scanner.  This lets users reference any one name of a "same_as"
+        # group when keying grid_pts.
+        def _name_set(joined):
+            return set(joined.split("+"))
+
+        N = [None] * self.dim
+
+        for key, value in grid_pts.items():
+            matched_index = None
+            for i, joined in enumerate(param_names):
+                if key in _name_set(joined):
+                    matched_index = i
+                    break
+            if matched_index is None:
+                raise RuntimeError(
+                    "Grid scanner: parameter \"{0}\" listed in grid_pts "
+                    "is not a scanned parameter.".format(key))
+            if N[matched_index] is not None:
+                raise RuntimeError(
+                    "Grid scanner: parameter \"{0}\" is specified more "
+                    "than once in grid_pts.".format(key))
+            N[matched_index] = int(value)
+
+        for i, joined in enumerate(param_names):
+            if N[i] is None:
+                raise RuntimeError(
+                    "Grid scanner: number of grid points for parameter "
+                    "\"{0}\" is not specified in grid_pts.".format(joined))
+
+        if self.mpi_rank == 0:
+            print("Grid scanner: parameter -> number of grid points mapping:")
+            for joined, n in zip(param_names, N):
+                print("    {0} -> {1}".format(joined, n))
+
+        self.size = int(np.prod(np.asarray(N)))
+        self.vecs = [np.linspace(0.0, 1.0, n) for n in N]
+
     # This runs the scanner.  This method is required.
     def run(self):
 

--- a/ScannerBit/src/scanners/simple/grid.cpp
+++ b/ScannerBit/src/scanners/simple/grid.cpp
@@ -12,6 +12,10 @@
 ///          (gregory.david.martinez@gmail.com)
 ///  \date 2013 August
 ///
+///  \author Anders Kvellestad
+///          (anders.kvellestad@fys.uio.no)
+///  \date 2026 May
+///
 ///  *********************************************
 
 #ifdef WITH_MPI
@@ -72,7 +76,63 @@ scanner_plugin(grid, version(1, 0, 0))
         rank = 0;
 #endif
 
-        std::vector<int> N = get_inifile_value<std::vector<int>>("grid_pts");
+        auto params = get_prior().getShownParameters();
+        std::vector<std::unordered_set<std::string>> paramSet = parse_sames(params);
+
+        YAML::Node grid_pts_node = get_inifile_node("grid_pts");
+        if (!grid_pts_node || !grid_pts_node.IsMap())
+        {
+            scan_err << "Grid Scanner:  \"grid_pts\" must be a YAML map from "
+                     << "\"<model>::<param>\" to integer, e.g.\n"
+                     << "    grid_pts:\n"
+                     << "      NormalDist::mu: 5\n"
+                     << "      NormalDist::sigma: 3" << scan_end;
+            return 1;
+        }
+
+        std::vector<int> N(ma, -1);
+
+        for (auto it = grid_pts_node.begin(); it != grid_pts_node.end(); ++it)
+        {
+            std::string key = it->first.as<std::string>();
+            int value = it->second.as<int>();
+
+            int matched_index = -1;
+            for (int i = 0; i < ma; ++i)
+            {
+                if (paramSet[i].find(key) != paramSet[i].end())
+                {
+                    matched_index = i;
+                    break;
+                }
+            }
+
+            if (matched_index < 0)
+            {
+                scan_err << "Grid Scanner:  parameter \"" << key
+                         << "\" listed in grid_pts is not a scanned parameter." << scan_end;
+            }
+            else if (N[matched_index] != -1)
+            {
+                scan_err << "Grid Scanner:  parameter \"" << key
+                         << "\" is specified more than once in grid_pts." << scan_end;
+            }
+            else
+            {
+                N[matched_index] = value;
+            }
+        }
+
+        for (int i = 0; i < ma; ++i)
+        {
+            if (N[i] == -1)
+            {
+                scan_err << "Grid Scanner:  number of grid points for parameter \"" << params[i]
+                         << "\" is not specified in grid_pts." << scan_end;
+                N[i] = 1;
+            }
+        }
+
         int NTot = 1;
 
         for (auto it = N.begin(), end = N.end(); it != end; it++)
@@ -80,61 +140,17 @@ scanner_plugin(grid, version(1, 0, 0))
             if (*it < 0)
                 *it = -*it;
             else if (*it == 0)
-                *it= 1;
+                *it = 1;
             NTot *= *it;
         }
 
-        if (N.size() != (unsigned int)ma)
-            scan_err << "Grid Scanner:  The dimension of gambit (" << ma
-                << ") does not match the dimension of the inputed grid_pts (" << N.size() << ")" << scan_end;
-              
-        YAML::Node node = get_inifile_node("parameters");
-        if (node)
+        if (rank == 0)
         {
-            auto params = get_prior().getShownParameters();
-            auto user_params = get_yaml_vector<std::string>(node);//node.as<std::vector<std::string>>();
-            
-            if (params.size() != user_params.size())
+            std::cout << "Grid Scanner:  parameter -> number of grid points mapping:" << std::endl;
+            for (int i = 0; i < ma; ++i)
             {
-                scan_err << "Grid Scanner:  The inputed parameter order is not the same size as the actual parameter number." << scan_end;
+                std::cout << "    " << params[i] << " -> " << N[i] << std::endl;                
             }
-            
-            std::vector<std::unordered_set<std::string>> paramSet = parse_sames(params);
-            
-            std::vector<int> N_temp(N.size(), -1);
-            for (int i = 0, end = user_params.size(); i < end; i++)
-            {
-                int k = 0;
-                for (int j = 0, endj = user_params.size(); j < endj; j++)
-                {
-                    auto it = paramSet[i].find(user_params[j]);
-                    if (it != paramSet[i].end())
-                    {
-                        N_temp[i] = N[j];
-                        
-                        if (k > 0)
-                        {
-                            scan_err << "Grid Scanner:  Parameter order specified repeats same parameter (" << user_params[i] << ")" << scan_end;
-                        }
-                        k++;
-                    }
-                }
-                
-                if (k == 0)
-                {
-                    scan_err << "Grid Scanner:  Parameter " << params[i] << " is not given a grid sampling rate." << scan_end;
-                }
-            }
-            
-            for (auto it = N_temp.begin(), end = N_temp.end(); it != end; ++it)
-            {
-                if (*it == -1)
-                {
-                    scan_err << "Grid Scanner:  Not all parameters are specified in the parameter order." << scan_end;
-                }
-            }
-            
-            N = N_temp;
         }
 
         like_ptr LogLike;

--- a/yaml_files/ScannerBit.yaml
+++ b/yaml_files/ScannerBit.yaml
@@ -61,12 +61,16 @@ Scanner:
     grid:
       plugin: grid
       like: LogLike
-      grid_pts: [5, 3]
-      
+      grid_pts:
+        EggBox::param_0: 5
+        EggBox::param_1: 3
+
     python_grid:
       like: LogLike
       plugin: python_grid
-      grid_pts: [5, 3]
+      grid_pts:
+        EggBox::param_0: 5
+        EggBox::param_1: 3
       run:
         my_test: 1.1
 

--- a/yaml_files/SpecBit_ScalarSingletDM_vacuum_stability.yaml
+++ b/yaml_files/SpecBit_ScalarSingletDM_vacuum_stability.yaml
@@ -71,7 +71,9 @@ Scanner:
       plugin: grid
       version: ">=1.0"
       like:  LogLike
-      grid_pts: [1,1]
+      grid_pts:
+        StandardModel_SLHA2::mT: 1
+        StandardModel_Higgs_running::mH: 1
 
 
 ObsLikes:

--- a/yaml_files/spartan.yaml
+++ b/yaml_files/spartan.yaml
@@ -90,7 +90,9 @@ Scanner:
       plugin: grid
       #version: ">=1.0"
       like: LogLike
-      grid_pts: [5, 3]
+      grid_pts:
+        NormalDist::mu: 5
+        NormalDist::sigma: 3
 
     de:
       plugin: diver

--- a/yaml_files/spartan_NUHM1.yaml
+++ b/yaml_files/spartan_NUHM1.yaml
@@ -60,16 +60,6 @@ Scanner:
       like:  LogLike
       point_number: 20
 
-    square_grid:
-      plugin: square_grid
-      like: LogLike
-      grid_pts: 3
-
-    grid:
-      plugin: grid
-      like: LogLike
-      grid_pts: [2, 2, 3]
-
 
 ObsLikes:
 


### PR DESCRIPTION
grid_pts must now be a YAML map from "<model>::<param>" to integer, removing the silent dependence on the alphabetical sort of the shown parameter names.  The example YAML files that use the grid scanner have been updated, and on rank 0 the scanner logs the resolved parameter -> grid points mapping at startup.