### PR TITLE
Add autogenerated gambit_backend_interfaces.yaml to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ contrib/YODA-*/
 # Local configuration files
 config/*_locations.yaml
 config/gambit_bits.yaml
+config/gambit_backend_interfaces.yaml
 config/gambit_backends.yaml
 
 # Scratch files


### PR DESCRIPTION
PR #595 introduced a change to the backend harvester script that renamed the auto generated file in the `config` folder from `gambit_backends.yaml` to `gambit_backend_interfaces.yaml`

This PR adds this file to the ones that should be ignored by git.

Technically, `config/gambit_backends.yaml` could be dropped as the file is no longer generated. I have kept it in the list, however,  to avoid it showing up in `git status` as untracked file again in case it was previously generated and the local repo was not fully cleaned yet.