### PR TITLE
Update only when different for several harvester scripts

### DIFF
--- a/Backends/scripts/backend_harvester.py
+++ b/Backends/scripts/backend_harvester.py
@@ -140,12 +140,16 @@ def main(argv):
 // Automatically-generated list of frontends.     
 """
 
-    for h in frontend_headers:
+    for h in sorted(frontend_headers):
         towrite+='#include \"gambit/Backends/frontends/{0}\"\n'.format(h)
     towrite+="\n#endif // defined __backend_rollcall_hpp__\n"
 
-    with open("./Backends/include/gambit/Backends/backend_rollcall.hpp","w") as f:
-        f.write(towrite)
+    # Don't touch any existing file unless it is actually different from what we will create
+    if not os.path.isdir("./scratch/build_time"): os.makedirs("./scratch/build_time")
+    header = "./Backends/include/gambit/Backends/backend_rollcall.hpp"
+    candidate = "./scratch/build_time/backend_rollcall.hpp.candidate"
+    with open(candidate,"w") as f: f.write(towrite)
+    update_only_if_different(header, candidate)
 
     # Generate a c++ header containing all the frontend headers we have just harvested.
     towrite = """//   GAMBIT: Global and Modular BSM Inference Tool
@@ -193,17 +197,20 @@ def main(argv):
                                                   
 // Regular backend type definitions.              
 """
-    for h in backend_type_headers:
+    for h in sorted(backend_type_headers):
         towrite+='#include \"gambit/Backends/backend_types/{0}\"\n'.format(h)
 
     towrite += "\n// BOSSed backend type definitions.\n"
-    for h in bossed_backend_type_headers:
+    for h in sorted(bossed_backend_type_headers):
         towrite+='#include \"gambit/Backends/backend_types/{0}\"\n'.format(h)
 
     towrite+="\n#endif // defined __backend_types_rollcall_hpp__\n"
 
-    with open("./Backends/include/gambit/Backends/backend_types_rollcall.hpp","w") as f:
-        f.write(towrite)
+    # Don't touch any existing file unless it is actually different from what we will create
+    header = "./Backends/include/gambit/Backends/backend_types_rollcall.hpp"
+    candidate = "./scratch/build_time/backend_types_rollcall.hpp.candidate"
+    with open(candidate,"w") as f: f.write(towrite)
+    update_only_if_different(header, candidate)
 
     if verbose:
         print("Generated backend_rollcall.hpp.")

--- a/ColliderBit/scripts/collider_harvester.py
+++ b/ColliderBit/scripts/collider_harvester.py
@@ -46,6 +46,9 @@ def main(argv):
         verbose = True
         print('collider_harvester.py: verbose=True')
 
+    # Make sure the scratch directory for candidate files exists (it may not when running this script standalone)
+    if not os.path.isdir("./scratch/build_time"): os.makedirs("./scratch/build_time")
+
     # Get list of models to include in ColliderBit_model_rollcall.hpp
     model_headers.update(retrieve_generic_headers(verbose,"./ColliderBit/include/gambit/ColliderBit/models","model", set()))
 
@@ -78,8 +81,11 @@ def main(argv):
     for h in model_headers:
         towrite+='#include \"gambit/ColliderBit/models/{0}\"\n'.format(h)
 
-    with open("./ColliderBit/include/gambit/ColliderBit/ColliderBit_models_rollcall.hpp","w") as f:
-        f.write(towrite)
+    # Don't touch any existing file unless it is actually different from what we will create
+    header = "./ColliderBit/include/gambit/ColliderBit/ColliderBit_models_rollcall.hpp"
+    candidate = "./scratch/build_time/ColliderBit_models_rollcall.hpp.candidate"
+    with open(candidate,"w") as f: f.write(towrite)
+    update_only_if_different(header, candidate)
 
     # Generate a C++ header containing Py8Collider typedefs for all the model headers we have just harvested.
     towrite = """//   GAMBIT: Global and Modular BSM Inference Tool
@@ -130,8 +136,11 @@ namespace Gambit
 
     towrite+="    #endif\n    /// @}\n\n  }\n}\n"
 
-    with open("./ColliderBit/include/gambit/ColliderBit/colliders/Pythia8/Py8Collider_typedefs.hpp","w") as f:
-        f.write(towrite)
+    # Don't touch any existing file unless it is actually different from what we will create
+    header = "./ColliderBit/include/gambit/ColliderBit/colliders/Pythia8/Py8Collider_typedefs.hpp"
+    candidate = "./scratch/build_time/Py8Collider_typedefs.hpp.candidate"
+    with open(candidate,"w") as f: f.write(towrite)
+    update_only_if_different(header, candidate)
 
     if verbose:
         print("\nGenerated ColliderBit_models_rollcall.hpp.")

--- a/ColliderBit/scripts/collider_harvester.py
+++ b/ColliderBit/scripts/collider_harvester.py
@@ -78,7 +78,7 @@ def main(argv):
                                                   
 """
 
-    for h in model_headers:
+    for h in sorted(model_headers):
         towrite+='#include \"gambit/ColliderBit/models/{0}\"\n'.format(h)
 
     # Don't touch any existing file unless it is actually different from what we will create
@@ -120,7 +120,7 @@ namespace Gambit
       typedef Py8Collider<Pythia_default::Pythia8::Pythia, Pythia_default::Pythia8::Event, void> Py8Collider_defaultversion;
 """
 
-    for h in model_headers:
+    for h in sorted(model_headers):
         if h not in ignore_model_headers:
             m = re.sub(".hpp", "", h)
             towrite+='      typedef Py8Collider<Pythia_{0}_default::Pythia8::Pythia, Pythia_{0}_default::Pythia8::Event, void> Py8Collider_{0}_defaultversion;\n'.format(m)
@@ -129,7 +129,7 @@ namespace Gambit
     #else                                         \n\
       typedef Py8Collider<Pythia_default::Pythia8::Pythia, Pythia_default::Pythia8::Event, Pythia_default::Pythia8::GAMBIT_hepmc_writer> Py8Collider_defaultversion;\n"
 
-    for h in model_headers:
+    for h in sorted(model_headers):
         if h not in ignore_model_headers:
             m = re.sub(".hpp", "", h)
             towrite+='      typedef Py8Collider<Pythia_{0}_default::Pythia8::Pythia, Pythia_{0}_default::Pythia8::Event, Pythia_{0}_default::Pythia8::GAMBIT_hepmc_writer> Py8Collider_{0}_defaultversion;\n'.format(m)

--- a/Elements/scripts/module_harvester.py
+++ b/Elements/scripts/module_harvester.py
@@ -164,7 +164,7 @@ def main(argv):
 // Automatically-generated list of module types.  
 """
 
-    for h in module_type_headers:
+    for h in sorted(module_type_headers):
         towrite+="#include \"{0}\"\n".format(h)
     towrite+="""
 #endif // defined __module_types_rollcall_hpp__
@@ -289,7 +289,7 @@ def main(argv):
 namespace Gambit                                  
 {                                                 
 """
-    for tp in type_packs:
+    for tp in sorted(type_packs):
         towrite+="""
   template class backend_functor_common<{0}>;
   template class backend_functor<{0}>;""".format(tp)+"\n"
@@ -339,7 +339,7 @@ namespace Gambit
 namespace Gambit                                  
 {                                                 
 """
-    for t in types:
+    for t in sorted(types):
         towrite+="  template class module_functor<{0}>;\n".format(t)
     towrite+="""}
 

--- a/Models/scripts/model_harvester.py
+++ b/Models/scripts/model_harvester.py
@@ -95,12 +95,16 @@ def main(argv):
 // Automatically-generated list of models.        
 """
 
-    for h in model_headers:
+    for h in sorted(model_headers):
         towrite+='#include \"gambit/Models/models/{0}\"\n'.format(h)
     towrite+="\n#endif // defined __model_rollcall_hpp__\n"
 
-    with open("./Models/include/gambit/Models/model_rollcall.hpp","w") as f:
-        f.write(towrite)
+    # Don't touch any existing file unless it is actually different from what we will create
+    if not os.path.isdir("./scratch/build_time"): os.makedirs("./scratch/build_time")
+    header = "./Models/include/gambit/Models/model_rollcall.hpp"
+    candidate = "./scratch/build_time/model_rollcall.hpp.candidate"
+    with open(candidate,"w") as f: f.write(towrite)
+    update_only_if_different(header, candidate)
 
     # Generate a c++ header containing all the model type headers we have just harvested.
     towrite = """//   GAMBIT: Global and Modular BSM Inference Tool
@@ -135,12 +139,15 @@ def main(argv):
 // Automatically-generated list of model types.   
 """
 
-    for h in model_type_headers:
+    for h in sorted(model_type_headers):
         towrite+='#include \"gambit/Models/model_types/{0}\"\n'.format(h)
     towrite+="\n#endif // defined __model_types_rollcall_hpp__\n"
 
-    with open("./Models/include/gambit/Models/model_types_rollcall.hpp","w") as f:
-        f.write(towrite)
+    # Don't touch any existing file unless it is actually different from what we will create
+    header = "./Models/include/gambit/Models/model_types_rollcall.hpp"
+    candidate = "./scratch/build_time/model_types_rollcall.hpp.candidate"
+    with open(candidate,"w") as f: f.write(towrite)
+    update_only_if_different(header, candidate)
 
     if verbose:
         print("\nGenerated model_rollcall.hpp.")

--- a/Models/scripts/particle_harvester.py
+++ b/Models/scripts/particle_harvester.py
@@ -174,8 +174,12 @@ namespace Gambit
 }                                                 \n"
 
 
-  with open("./Models/src/particle_database.cpp","w") as f:
-    f.write(towrite)
+  # Don't touch any existing file unless it is actually different from what we will create
+  if not os.path.isdir("./scratch/build_time"): os.makedirs("./scratch/build_time")
+  source = "./Models/src/particle_database.cpp"
+  candidate = "./scratch/build_time/particle_database.cpp.candidate"
+  with open(candidate,"w") as f: f.write(towrite)
+  update_only_if_different(source, candidate)
 
 # Handle command line arguments (verbosity)
 if __name__ == "__main__":

--- a/Printers/scripts/printer_harvester.py
+++ b/Printers/scripts/printer_harvester.py
@@ -89,7 +89,7 @@ def main(argv):
 // Automatically-generated list of printers.      
 """
 
-    for h in printer_headers:
+    for h in sorted(printer_headers):
         towrite+='#include \"gambit/Printers/printers/{0}\"\n'.format(h)
     towrite+="\n#endif // defined __printer_rollcall_hpp__\n"
 

--- a/Utils/scripts/harvesting_tools.py
+++ b/Utils/scripts/harvesting_tools.py
@@ -760,12 +760,16 @@ def make_module_rollcall(rollcall_headers, verbose):
 
 """
 
-    for h in rollcall_headers:
+    for h in sorted(rollcall_headers):
         towrite += '#include \"{0}\"\n'.format(h)
     towrite += "\n#endif // defined __module_rollcall_hpp__\n"
 
-    with open("./Core/include/gambit/Core/module_rollcall.hpp", "w") as f:
-        f.write(towrite)
+    # Don't touch any existing file unless it is actually different from what we will create
+    if not os.path.isdir("./scratch/build_time"): os.makedirs("./scratch/build_time")
+    header = "./Core/include/gambit/Core/module_rollcall.hpp"
+    candidate = "./scratch/build_time/module_rollcall.hpp.candidate"
+    with open(candidate,"w") as f: f.write(towrite)
+    update_only_if_different(header, candidate)
 
     if verbose:
         print("Found GAMBIT Core.  Generated module_rollcall.hpp.\n")

--- a/cmake/utilities.cmake
+++ b/cmake/utilities.cmake
@@ -271,6 +271,14 @@ macro(add_gambit_custom target filename HARVESTER DEPS)
   if (NOT "${ARGN}" STREQUAL "")
     set(ditch_string "-x __not_a_real_name__,${ARGN}")
   endif()
+  # Record the full harvester command in a stamp file that is only touched when the
+  # command changes, so that the harvesters rerun when e.g. the -Ditch list changes,
+  # but not after every reconfiguration (as a dependency on CMakeCache.txt would cause).
+  set(harvester_options_stamp ${CMAKE_BINARY_DIR}/${target}_options.stamp)
+  file(WRITE ${harvester_options_stamp}.candidate "${PYTHON_EXECUTABLE} ${${HARVESTER}} ${ditch_string}\n")
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                  ${harvester_options_stamp}.candidate ${harvester_options_stamp})
+  file(REMOVE ${harvester_options_stamp}.candidate)
   add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/${filename}
                      COMMAND ${PYTHON_EXECUTABLE} ${${HARVESTER}} ${ditch_string}
                      COMMAND touch ${CMAKE_BINARY_DIR}/${filename}
@@ -278,7 +286,7 @@ macro(add_gambit_custom target filename HARVESTER DEPS)
                      DEPENDS ${${HARVESTER}}
                              ${HARVEST_TOOLS}
                              ${${DEPS}}
-                             ${CMAKE_BINARY_DIR}/CMakeCache.txt) #CMAKE_CACHEFILE_DIR is the same as CMAKE_BINARY_DIR
+                             ${harvester_options_stamp})
   add_custom_target(${target} DEPENDS ${CMAKE_BINARY_DIR}/${filename})
 endmacro()
 
@@ -441,6 +449,15 @@ function(add_standalone executablename)
     endforeach()
     list(APPEND STANDALONE_SOURCES ${STANDALONE_FUNCTORS})
 
+    # Record the full facilitator command in a stamp file that is only touched when the
+    # command changes, so that the functors source is regenerated when e.g. the module list
+    # changes, but not after every reconfiguration (as a dependency on CMakeCache.txt would cause).
+    set(facilitator_options_stamp ${CMAKE_BINARY_DIR}/functors_for_${executablename}_options.stamp)
+    file(WRITE ${facilitator_options_stamp}.candidate "${PYTHON_EXECUTABLE} ${STANDALONE_FACILITATOR} ${executablename} -m __not_a_real_name__,${COMMA_SEPARATED_MODULES}\n")
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    ${facilitator_options_stamp}.candidate ${facilitator_options_stamp})
+    file(REMOVE ${facilitator_options_stamp}.candidate)
+
     # Set up the target to call the facilitator script to make the functors source file for this standalone.
     add_custom_command(OUTPUT ${STANDALONE_FUNCTORS}
                        COMMAND ${PYTHON_EXECUTABLE} ${STANDALONE_FACILITATOR} ${executablename} -m __not_a_real_name__,${COMMA_SEPARATED_MODULES}
@@ -449,7 +466,7 @@ function(add_standalone executablename)
                        DEPENDS modules_harvested
                                ${STANDALONE_FACILITATOR}
                                ${HARVEST_TOOLS}
-                               ${CMAKE_BINARY_DIR}/CMakeCache.txt) #CMAKE_CACHEFILE_DIR is the same as CMAKE_BINARY_DIR
+                               ${facilitator_options_stamp})
 
     # All the standalones need linking to HepMC, if HepMC is not excluced.
     # TODO: Avoid this if possible.


### PR DESCRIPTION
This PR writes a few scratch build files for the results of some of the harvester scripts, and checks whether they are different before updating the files. The purpose of this is that when rerunning cmake, we want to avoid rebuilding files that aren't actually any different.

My test for this was running a build, running cmake .. (with no code changes at all), and rerunning make again to see what still builds. This reduces it quite a bit, but there are still a few files that rebuild. There are few enough that I do not think it is too much of a problem. These are SpecBit files that are being built because there is a FlexibleSUSY configure script that is generating some config header (only included in SpecBit files). I can try to solve that in another PR if desired.