### PR TITLE
Build: fix opt-in backend trimmer to honour BACKEND_REQ_FROM_GROUP

### DIFF
--- a/Utils/scripts/harvesting_tools.py
+++ b/Utils/scripts/harvesting_tools.py
@@ -787,7 +787,13 @@ def _extract_be_capabilities(text):
             caps.add(quotes[-1])
     return caps
 
-_BIT_REQ_RE = re.compile(r'\b(?:LONG_)?BACKEND_REQ(?:_FROM_GROUP)?\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)')
+# Plain (LONG_)BACKEND_REQ(capability, ...): the capability is the 1st argument.
+# The negative lookahead keeps this from also matching the _FROM_GROUP form.
+_BIT_REQ_RE = re.compile(r'\b(?:LONG_)?BACKEND_REQ(?!_FROM_GROUP)\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)')
+# (LONG_)BACKEND_REQ_FROM_GROUP(group, capability, ...): the capability is the
+# 2nd argument; the 1st argument is the group name, which is not a backend
+# capability and so must not be treated as one.
+_BIT_REQ_GROUP_RE = re.compile(r'\b(?:LONG_)?BACKEND_REQ_FROM_GROUP\s*\(\s*[A-Za-z_][A-Za-z0-9_]*\s*,\s*([A-Za-z_][A-Za-z0-9_]*)')
 _BIT_NCF_RE = re.compile(r'\bNEEDS_CLASSES_FROM\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)')
 
 
@@ -843,8 +849,9 @@ def compute_bits_per_backend(project_root, frontend_dir):
                         text = comment_remover(f.read())
                 except (IOError, OSError):
                     continue
-                for m in _BIT_REQ_RE.finditer(text): bit_caps.add(m.group(1))
-                for m in _BIT_NCF_RE.finditer(text): bit_ncfs.add(m.group(1))
+                for m in _BIT_REQ_RE.finditer(text):       bit_caps.add(m.group(1))
+                for m in _BIT_REQ_GROUP_RE.finditer(text): bit_caps.add(m.group(1))
+                for m in _BIT_NCF_RE.finditer(text):       bit_ncfs.add(m.group(1))
         for be in all_backends:
             if (caps_by_backend[be] & bit_caps) or (be in bit_ncfs):
                 result[be].add(bit)


### PR DESCRIPTION
The recent changes to trim backends depending on what modules you load used some regex that missed some cases. Specifically, if you built with ColliderBit, and not DarkBit, nulike would be ditched. This was because the way the regex worked, it extracted the first time in the BACKENDS_REQ macro, and nulike is specified in a different macro where it is the second entry.

This should work, and can be easily tested from running cmake without darkbit (you will see nulike is present)