### PR TITLE
cmake: support modern ROOT in check_root_std_flag (ROOT_CXX_STANDARD, C++20/23)

### DIFF
--- a/cmake/optional.cmake
+++ b/cmake/optional.cmake
@@ -212,8 +212,18 @@ endif()
 
 # Helper function to check if ROOT has been compiled with the same standard as we are using here.  If not, downgrade to the standard that ROOT was compiled with.
 function(check_root_std_flag)
+  # Modern ROOT (CMake config) versions expose the standard they were built
+  # with directly via ROOT_CXX_STANDARD, rather than embedding a -std=c++NN
+  # flag in ROOT_CXX_FLAGS. Prefer that when present.
+  if (NOT ROOT_USES_STD AND DEFINED ROOT_CXX_STANDARD AND NOT "${ROOT_CXX_STANDARD}" STREQUAL "")
+    set(ROOT_USES_STD TRUE)
+    set(ROOT_STD "${ROOT_CXX_STANDARD}")
+    set(ROOT_CXX_FLAG "-std=c++${ROOT_CXX_STANDARD}")
+    set(ROOT_CXX_FLAG_RE "-std=c\\+\\+${ROOT_CXX_STANDARD}")
+    message("${BoldYellow}   This ROOT was compiled with ${ROOT_CXX_FLAG} (from ROOT_CXX_STANDARD).${ColourReset}")
+  endif()
   # Loop over C++ standards
-  set(std_list "17;1z;14;1y;11;0x")
+  set(std_list "23;20;2a;17;1z;14;1y;11;0x")
   foreach(std ${std_list})
     set(CXX_FLAG "-std=c++${std}")
     set(CXX_FLAG_RE "-std=c\\+\\+${std}")


### PR DESCRIPTION
## Problem

Configuring with `-DWITH_ROOT=ON` against a recent ROOT fails at cmake time with

```
Unable to detect what flavour of C++ your installation of ROOT has been compiled with; please set -DWITH_ROOT=OFF.
```

because `check_root_std_flag` in `cmake/optional.cmake` greps `ROOT_CXX_FLAGS` for a `-std=c++NN` flag and only knows the list `17;1z;14;1y;11;0x`. Modern ROOT builds (CMake config packages, e.g. conda-forge) are commonly compiled with C++20, and expose the standard through the `ROOT_CXX_STANDARD` variable instead of embedding `-std=` in `ROOT_CXX_FLAGS`, so both assumptions fail.

## Fix (minimal)

* When `ROOT_CXX_STANDARD` is defined (modern `ROOTConfig.cmake`), use it directly to set `ROOT_STD` / `ROOT_CXX_FLAG` before the flag-grepping loop.
* Extend the fallback flag list with `23;20;2a` for ROOT builds that do still embed the flag.

The existing detection path and the downgrade logic are unchanged; the new branch is guarded so it only fires when `ROOT_CXX_STANDARD` is actually provided.

## Testing

* conda-forge ROOT **6.36.04** (C++20, `ROOT_CXX_STANDARD=20`), macOS: configure previously aborted with the message above, now succeeds and reports `This ROOT was compiled with -std=c++20 (from ROOT_CXX_STANDARD)`; the subsequent NeutrinoBit-targeted build (including the `MINOS_chi2calc` backend, which needs ROOT) completes and runs.
* Behaviour is unchanged for older ROOT that embeds `-std=` in `ROOT_CXX_FLAGS` (e.g. 6.28.12, C++17), which takes the pre-existing code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)