### PR TITLE
Fix Bug: Event scaling was happening from initial cross-section

### DIFF
--- a/ColliderBit/include/gambit/ColliderBit/ColliderBit_MC_rollcall.hpp
+++ b/ColliderBit/include/gambit/ColliderBit/ColliderBit_MC_rollcall.hpp
@@ -262,7 +262,7 @@
     #define FUNCTION getATLASAnalysisContainer
     START_FUNCTION(AnalysisContainer)
     NEEDS_MANAGER(RunMC, MCLoopInfo)
-    DEPENDENCY(InitialTotalCrossSection, map_str_xsec_container)
+    DEPENDENCY(TotalCrossSection, map_str_xsec_container)
     #undef FUNCTION
   #undef CAPABILITY
 
@@ -271,7 +271,7 @@
     #define FUNCTION getCMSAnalysisContainer
     START_FUNCTION(AnalysisContainer)
     NEEDS_MANAGER(RunMC, MCLoopInfo)
-    DEPENDENCY(InitialTotalCrossSection, map_str_xsec_container)
+    DEPENDENCY(TotalCrossSection, map_str_xsec_container)
     #undef FUNCTION
   #undef CAPABILITY
 
@@ -280,7 +280,7 @@
     #define FUNCTION getIdentityAnalysisContainer
     START_FUNCTION(AnalysisContainer)
     NEEDS_MANAGER(RunMC, MCLoopInfo)
-    DEPENDENCY(InitialTotalCrossSection, map_str_xsec_container)
+    DEPENDENCY(TotalCrossSection, map_str_xsec_container)
     #undef FUNCTION
   #undef CAPABILITY
   /// @}

--- a/ColliderBit/src/getAnalysisContainer.cpp
+++ b/ColliderBit/src/getAnalysisContainer.cpp
@@ -114,7 +114,7 @@ namespace Gambit
     {                                                              \
       using namespace Pipes::NAME;                                 \
                                                                     \
-      map_str_xsec_container Totalxsec = *Dep::InitialTotalCrossSection; \
+      map_str_xsec_container Totalxsec = *Dep::TotalCrossSection; \
                                        \
       getAnalysisContainer(result, #EXPERIMENT, *Dep::RunMC,       \
        Totalxsec[Dep::RunMC->current_collider()], *Loop::iteration);                 \


### PR DESCRIPTION
Very trivial Bug. Spotted by Roberto when debugging SMEFT vlq cross-sections